### PR TITLE
Allow copy-file from remoto to local paths

### DIFF
--- a/remoto.el
+++ b/remoto.el
@@ -702,7 +702,27 @@ Pass DIR-FLAG and SUFFIX through to `make-temp-file'."
 (defalias 'remoto--handle-delete-file #'remoto--read-only)
 (defalias 'remoto--handle-delete-directory #'remoto--read-only)
 (defalias 'remoto--handle-rename-file #'remoto--read-only)
-(defalias 'remoto--handle-copy-file #'remoto--read-only)
+(defun remoto--handle-copy-file (file newname
+                                      &optional ok-if-already-exists keep-time
+                                      preserve-uid-gid preserve-permissions)
+  "Copy FILE to NEWNAME. Works when destination is outside remoto.
+OK-IF-ALREADY-EXISTS, KEEP-TIME, PRESERVE-UID-GID, and
+PRESERVE-PERMISSIONS are passed through to `copy-file'."
+  (if (string-match-p remoto--path-regexp newname)
+      (remoto--read-only 'copy-file file newname)
+    (let ((local-copy (remoto--handle-file-local-copy file)))
+      (unless local-copy
+        (error "Remoto: failed to download %s" file))
+      (unwind-protect
+          (let ((inhibit-file-name-handlers
+                 (cons #'remoto-file-name-handler
+                       (and (eq inhibit-file-name-operation 'copy-file)
+                            inhibit-file-name-handlers)))
+                (inhibit-file-name-operation 'copy-file))
+            (copy-file local-copy newname ok-if-already-exists keep-time
+                       preserve-uid-gid preserve-permissions))
+        (when (file-exists-p local-copy)
+          (delete-file local-copy))))))
 (defalias 'remoto--handle-set-file-modes #'remoto--read-only)
 (defalias 'remoto--handle-set-file-times #'remoto--read-only)
 

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -417,6 +417,36 @@
       (expect (make-directory "/github:testowner/testrepo@main:/newdir")
               :to-throw 'user-error))))
 
+;;; copy-file
+
+(describe "copy-file"
+  (it "copies remoto file to local destination"
+    (remoto-test-with-cache
+      (spy-on 'remoto--fetch-file-content :and-return-value "mock file content")
+      (let ((dest (make-temp-file "remoto-copy-test-")))
+        (unwind-protect
+            (progn
+              (copy-file "/github:testowner/testrepo@main:/src/main.el" dest t)
+              (expect (with-temp-buffer
+                        (insert-file-contents dest)
+                        (buffer-string))
+                      :to-equal "mock file content"))
+          (delete-file dest)))))
+
+  (it "signals read-only when destination is remoto"
+    (remoto-test-with-cache
+      (expect (copy-file "/github:testowner/testrepo@main:/src/main.el"
+                         "/github:testowner/testrepo@main:/src/copy.el")
+              :to-throw 'user-error)))
+
+  (it "signals read-only when copying local file to remoto"
+    (remoto-test-with-cache
+      (let ((src (make-temp-file "remoto-copy-src-")))
+        (unwind-protect
+            (expect (copy-file src "/github:testowner/testrepo@main:/dest.el")
+                    :to-throw 'user-error)
+          (delete-file src))))))
+
 ;;; Path normalization
 
 (describe "remoto--normalize-path"


### PR DESCRIPTION
Closes: #8 

Replace the blanket read-only handler for copy-file with one that distinguishes direction: copying to a remoto destination still errors, but copying from remoto to a local path downloads via file-local-copy and writes to the target. This enables Dired's C command for saving remote files locally.