### PR TITLE
Use search API for repo completion; fix auth timeout and error handling

### DIFF
--- a/README.org
+++ b/README.org
@@ -125,7 +125,7 @@ We can only imagine a world where git's transport layer gives you a browsable fi
 - Timestamps in dired are synthetic (the tree API has no timestamps).
 - Very large repos (100k+ files) use slower per-directory fetching.
 - Rate limit: 5,000 requests/hour (normal browsing stays well within this).
-- Repo completion at ~/github:owner/~ shows at most 100 repos (sorted by recently updated). Use ~remoto-browse~ to search beyond that.
+- Repo completion at ~/github:owner/~ shows the 30 most recently updated repos on empty input. Typing narrows via the GitHub search API.
 
 * Changelog
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -183,7 +183,8 @@ This returns one directory level at a time. The tree cache stores what it has an
 | `file-name-completion` | Delegate to `try-completion` on completions list |
 | `insert-file-contents` | Fetch file content via API, insert into buffer |
 | `insert-directory` | Format dired-compatible listing from tree cache |
-| `expand-file-name` | Normalize path components, handle relative paths under remoto dirs |
+| `expand-file-name` | Normalize path components, handle relative paths under remoto dirs; for partial paths (e.g. `/github:owner/`) concatenates directly |
+| `file-accessible-directory-p` | Delegates to `file-directory-p` - remote dirs are always readable |
 | `file-truename` | Return the path as-is (no symlink resolution) |
 | `file-remote-p` | Return the `/github:owner/repo@ref:` prefix (or method/host on request); handles partial paths |
 | `file-local-copy` | Download to temp file, return temp path |
@@ -268,8 +269,8 @@ Completion levels:
 | Input | Directory part | File part | Action |
 |---|---|---|---|
 | `/github:tor` | `/github:` | `tor` | Search users/orgs matching "tor" via `search/users` API |
-| `/github:torvalds/` | `/github:torvalds/` | (empty) | List repos via `users/torvalds/repos` API |
-| `/github:torvalds/lin` | `/github:torvalds/` | `lin` | Filter repos starting with "lin" |
+| `/github:torvalds/` | `/github:torvalds/` | (empty) | Show 30 most recently updated repos via `search/repositories?q=user:torvalds&sort=updated` |
+| `/github:torvalds/lin` | `/github:torvalds/` | `lin` | Search repos matching "lin" via `search/repositories?q=lin+in:name+user:torvalds` |
 | `/github:torvalds/linux@` | `/github:torvalds/` | `linux@` | List branches via `repos/torvalds/linux/branches` API |
 | `/github:torvalds/linux@master:` | `/github:torvalds/linux@master:` | (empty) | File-level completion (existing tree-based) |
 
@@ -278,12 +279,13 @@ Hitting RET on `/github:owner/repo` (without `@ref:`) resolves the default branc
 New API functions:
 
 - `remoto--search-users` - calls `search/users?q=PREFIX&per_page=30`. Caches results in `remoto--users-cache` (TTL-based, same as `remoto-search-cache-ttl`). Supports client-side narrowing: typing "torv" filters cached "tor" results without a new API call. Requires min 2 characters.
-- `remoto--fetch-user-repos` - calls `users/OWNER/repos?per_page=100&sort=updated`. Caches results in `remoto--user-repos-cache` (TTL-based).
+- `remoto--recent-owner-repos` - calls `search/repositories?q=user:OWNER&sort=updated&per_page=30`. Returns the 30 most recently pushed repos for an owner. Used when the input is empty at `/github:OWNER/`.
+- `remoto--search-owner-repos` - calls `search/repositories?q=QUERY+in:name+user:OWNER&per_page=100`. Searches repos by name within an owner. Supports client-side narrowing from cached shorter queries. Requires min 2 characters.
 
 New caches:
 
 - `remoto--users-cache` - hash table: query string -> `(TIMESTAMP . USER-NAMES)`.
-- `remoto--user-repos-cache` - hash table: owner string -> `(TIMESTAMP . REPO-NAMES)`.
+- `remoto--search-cache` - unified cache: key string -> `(TIMESTAMP . RESULTS)`. Used for user search (`\0users:PREFIX`), recent repos (`\0repos-recent:OWNER`), and repo search (`\0repos:OWNER/QUERY`).
 
 Partial path handling:
 
@@ -291,7 +293,7 @@ The file-name handler now recognizes partial paths (`/github:`, `/github:OWNER/`
 
 ## Unloading
 
-`remoto-unload-function` removes the `file-name-handler-alist` entry and all advice, and clears `remoto--users-cache` and `remoto--user-repos-cache`, ensuring clean `unload-feature` support.
+`remoto-unload-function` removes the `file-name-handler-alist` entry and all advice, and clears `remoto--users-cache`, ensuring clean `unload-feature` support.
 
 ## Limitations
 

--- a/changelog.org
+++ b/changelog.org
@@ -3,6 +3,23 @@
 
 Changes to the project, following Keep a Changelog conventions.
 
+* [1.3.0] - 2026-04-28
+
+** Changed
+- Repo completion now uses the GitHub search API instead of pre-fetching all repos. At ~/github:owner/~ with empty input, the 30 most recently updated repos are shown. As the user types, matching repos are fetched via ~search/repositories~. This replaces the old approach that fetched every repo for an owner (thousands for large orgs), which caused hangs.
+- Auth timeout in ~remoto--api~ now only applies on the first call before the authenticated user is known. Once auth succeeds, the timeout is skipped so slow API responses (e.g. search) are not aborted.
+- HTTP errors (404, 403) from the GitHub API no longer poison ~remoto--auth-failed~. Only actual auth-source/token errors trigger the unauthenticated fallback.
+
+** Added
+- ~remoto--search-owner-repos~ for searching repos within an owner via the search API, with caching and client-side narrowing for longer queries.
+- ~remoto--recent-owner-repos~ for fetching the 30 most recently pushed repos of an owner.
+- ~file-accessible-directory-p~ handler for remoto paths.
+- ~read-file-name-internal~ advice so ~/github:~ completion works correctly with Vertico/orderless when ~default-directory~ prefixes are present.
+- ~file-exists-p~ now returns t for ~/github:owner/repo~ partial paths (no ~@~), fixing completion transitions.
+
+** Removed
+- ~remoto--fetch-user-repos~ and ~remoto--user-repos-cache~. The "fetch all repos then filter client-side" approach is replaced by search API calls.
+
 * [1.2.0] - 2026-04-27
 
 ** Added

--- a/changelog.org
+++ b/changelog.org
@@ -13,6 +13,8 @@ Changes to the project, following Keep a Changelog conventions.
 ** Added
 - ~remoto--search-owner-repos~ for searching repos within an owner via the search API, with caching and client-side narrowing for longer queries.
 - ~remoto--recent-owner-repos~ for fetching the 30 most recently pushed repos of an owner.
+- Non-blocking completion: all pre-repo completion levels (user search, repo listing, branch listing) are wrapped in ~while-no-input~ so typing interrupts pending API calls instead of freezing Emacs.
+- Speculative pre-fetch: when user search returns results, an idle timer pre-fetches repos for the top match so the cache is warm by the time the user types ~/~.
 - ~file-accessible-directory-p~ handler for remoto paths.
 - ~read-file-name-internal~ advice so ~/github:~ completion works correctly with Vertico/orderless when ~default-directory~ prefixes are present.
 - ~file-exists-p~ now returns t for ~/github:owner/repo~ partial paths (no ~@~), fixing completion transitions.

--- a/changelog.org
+++ b/changelog.org
@@ -19,6 +19,7 @@ Changes to the project, following Keep a Changelog conventions.
 
 ** Fixed
 - ~expand-file-name~ no longer crashes on partial ~/github:~ paths (e.g. ~/github:owner/~ or ~/github:owner/repo@~). This broke ~embark-collect~ and ~embark-export~ at the repo and branch completion levels.
+- ~remoto--api~ now falls back to unauthenticated access when ghub raises a ~user-error~ about missing username config (e.g. ~github.user~ unset). Previously this was re-raised as an API error, crashing instead of falling through to the unauthenticated path.
 
 ** Removed
 - ~remoto--fetch-user-repos~ and ~remoto--user-repos-cache~. The "fetch all repos then filter client-side" approach is replaced by search API calls.

--- a/changelog.org
+++ b/changelog.org
@@ -17,6 +17,9 @@ Changes to the project, following Keep a Changelog conventions.
 - ~read-file-name-internal~ advice so ~/github:~ completion works correctly with Vertico/orderless when ~default-directory~ prefixes are present.
 - ~file-exists-p~ now returns t for ~/github:owner/repo~ partial paths (no ~@~), fixing completion transitions.
 
+** Fixed
+- ~expand-file-name~ no longer crashes on partial ~/github:~ paths (e.g. ~/github:owner/~ or ~/github:owner/repo@~). This broke ~embark-collect~ and ~embark-export~ at the repo and branch completion levels.
+
 ** Removed
 - ~remoto--fetch-user-repos~ and ~remoto--user-repos-cache~. The "fetch all repos then filter client-side" approach is replaced by search API calls.
 

--- a/remoto.el
+++ b/remoto.el
@@ -177,9 +177,17 @@ failures."
                 (message "Remoto: auth lookup timed out; retrying next call (see `remoto-auth-timeout')")
                 (setq result (remoto--ghub-get resource 'none endpoint)))
               result))
-        ;; Re-raise API errors (404, 403, etc.) as-is; these are not
-        ;; auth failures and must not poison remoto--auth-failed.
-        (user-error (signal (car err) (cdr err)))
+        ;; Re-raise API errors (404, 403, etc.) from remoto--ghub-get;
+        ;; these are not auth failures.  Other user-errors (e.g. ghub's
+        ;; "Cannot determine username") are auth config issues - fall
+        ;; through to unauthenticated access.
+        (user-error
+         (if (string-prefix-p "Remoto:" (cadr err))
+             (signal (car err) (cdr err))
+           (setq remoto--auth-failed t)
+           (message "Remoto: auth unavailable (%s); using unauthenticated access"
+                    (error-message-string err))
+           (remoto--ghub-get resource 'none endpoint)))
         (error
          (setq remoto--auth-failed t)
          (message "Remoto: auth unavailable (%s); using unauthenticated access"

--- a/remoto.el
+++ b/remoto.el
@@ -565,21 +565,30 @@ or `repo' for /github:OWNER/REPO@."
 (defun remoto--handle-file-name-all-completions (file directory)
   "Return completions for FILE in remote DIRECTORY.
 Handles three levels: user search at /github:, repo listing at
-/github:OWNER/, and file listing within a repo."
+/github:OWNER/, and file listing within a repo.  Network calls
+are wrapped in `while-no-input' so typing interrupts pending API
+requests instead of blocking Emacs."
   (if-let* ((partial (remoto--parse-partial-github-path directory)))
       (pcase (plist-get partial :level)
         ('root
          ;; Search users/orgs matching FILE
-         (when-let* ((users (remoto--search-users file)))
-           (thread-last users
-             (seq-filter (lambda (u) (string-prefix-p file u)))
-             (mapcar (lambda (u) (concat u "/"))))))
+         (let ((result (while-no-input (remoto--search-users file))))
+           (when (listp result)
+             (let ((filtered (thread-last result
+                               (seq-filter (lambda (u) (string-prefix-p file u))))))
+               ;; Pre-fetch repos for the top match so the cache is
+               ;; warm by the time the user types "/"
+               (when-let* ((top (car filtered)))
+                 (remoto--prefetch-owner-repos top))
+               (mapcar (lambda (u) (concat u "/")) filtered)))))
         ('owner
          ;; Repo completion at /github:OWNER/
-         (let ((owner (plist-get partial :owner)))
-           (if (string-empty-p file)
-               (remoto--recent-owner-repos owner)
-             (remoto--search-owner-repos owner file))))
+         (let* ((owner (plist-get partial :owner))
+                (result (while-no-input
+                          (if (string-empty-p file)
+                              (remoto--recent-owner-repos owner)
+                            (remoto--search-owner-repos owner file)))))
+           (when (listp result) result)))
         ('repo
          ;; Branch completion at /github:OWNER/REPO@
          (if (string-suffix-p ":" file)
@@ -587,12 +596,14 @@ Handles three levels: user search at /github:, repo listing at
              (list file)
            (let* ((owner (plist-get partial :owner))
                   (repo (plist-get partial :repo))
-                  (branches (remoto--fetch-branches owner repo)))
-             (thread-last branches
-               (seq-filter (lambda (b)
-                             (or (string-empty-p file)
-                                 (string-prefix-p file b))))
-               (mapcar (lambda (b) (concat b ":"))))))))
+                  (result (while-no-input
+                            (remoto--fetch-branches owner repo))))
+             (when (listp result)
+               (thread-last result
+                 (seq-filter (lambda (b)
+                               (or (string-empty-p file)
+                                   (string-prefix-p file b))))
+                 (mapcar (lambda (b) (concat b ":")))))))))
     ;; Full canonical path - existing behavior
     (when-let* ((parsed (remoto--parse-path directory)))
       (thread-last (remoto--tree-children parsed)
@@ -1184,6 +1195,24 @@ Uses client-side narrowing when a parent query is cached."
                              remoto--search-cache)
                     results)
                 (user-error nil)))))))))
+
+(defvar remoto--prefetch-timer nil
+  "Idle timer for speculative repo pre-fetching.")
+
+(defun remoto--prefetch-owner-repos (owner)
+  "Pre-fetch recent repos for OWNER on idle, warming the cache.
+Cancels any previously scheduled pre-fetch."
+  (when remoto--prefetch-timer
+    (cancel-timer remoto--prefetch-timer))
+  (setq remoto--prefetch-timer
+        (run-with-idle-timer
+         0.25 nil
+         (lambda ()
+           (setq remoto--prefetch-timer nil)
+           ;; Wrap in while-no-input so typing interrupts the
+           ;; synchronous HTTP call instead of blocking Emacs.
+           (while-no-input
+             (remoto--recent-owner-repos owner))))))
 
 (defun remoto--recent-owner-repos (owner)
   "Fetch recently-updated repos for OWNER, cached with TTL.

--- a/remoto.el
+++ b/remoto.el
@@ -165,12 +165,21 @@ failures."
     (if (eq auth 'none)
         (remoto--ghub-get resource 'none endpoint)
       (condition-case err
-          (let ((result (with-timeout (remoto-auth-timeout 'remoto--timed-out)
-                          (remoto--ghub-get resource auth endpoint))))
-            (when (eq result 'remoto--timed-out)
-              (message "Remoto: auth lookup timed out; retrying next call (see `remoto-auth-timeout')")
-              (setq result (remoto--ghub-get resource 'none endpoint)))
-            result)
+          ;; Only apply the auth timeout on the first call (before we
+          ;; know whether auth works).  Once the authenticated user is
+          ;; cached, auth-source won't block, so skip the timeout to
+          ;; avoid aborting slow HTTP responses.
+          (if remoto--authenticated-user
+              (remoto--ghub-get resource auth endpoint)
+            (let ((result (with-timeout (remoto-auth-timeout 'remoto--timed-out)
+                            (remoto--ghub-get resource auth endpoint))))
+              (when (eq result 'remoto--timed-out)
+                (message "Remoto: auth lookup timed out; retrying next call (see `remoto-auth-timeout')")
+                (setq result (remoto--ghub-get resource 'none endpoint)))
+              result))
+        ;; Re-raise API errors (404, 403, etc.) as-is; these are not
+        ;; auth failures and must not poison remoto--auth-failed.
+        (user-error (signal (car err) (cdr err)))
         (error
          (setq remoto--auth-failed t)
          (message "Remoto: auth unavailable (%s); using unauthenticated access"
@@ -209,9 +218,6 @@ Use after adding a GitHub token to auth-source."
   "Cache: query string -> (TIMESTAMP . USER-NAMES).
 Entries expire after `remoto-search-cache-ttl' seconds.")
 
-(defvar remoto--user-repos-cache (make-hash-table :test 'equal)
-  "Cache: owner string -> (TIMESTAMP . REPO-NAMES).
-Entries expire after `remoto-search-cache-ttl' seconds.")
 
 (defun remoto--resolve-ref (parsed)
   "Ensure PARSED `remoto-path' has a concrete ref, resolving if needed.
@@ -404,11 +410,20 @@ Pass remaining ARGS to the resolved handler."
 
 (defun remoto--handle-file-exists-p (filename)
   "Return t if FILENAME exists in the remote repo.
-Also returns t for partial paths used during completion."
+Also returns t for partial paths used during completion,
+including owner/repo paths that haven't added @ yet."
   (cond
    ((string-match (rx bos "/github:" (? "/") eos) filename) t)
    ((remoto--parse-partial-github-path
      (remoto--handle-file-name-as-directory filename))
+    t)
+   ;; /github:owner/repo (no @) - valid during completion
+   ((string-match (rx bos "/github:"
+                      (+ (not (any "/:@")))
+                      "/"
+                      (+ (not (any "/:@")))
+                      (? "/") eos)
+                  filename)
     t)
    (t
     (when-let* ((parsed (remoto--parse-path filename)))
@@ -428,6 +443,11 @@ Also returns t for partial paths like /github: and /github:OWNER/."
     (when-let* ((parsed (remoto--parse-path filename))
                 (entry (remoto--tree-entry parsed)))
       (equal "tree" (alist-get 'type entry))))))
+
+(defun remoto--handle-file-accessible-directory-p (filename)
+  "Return t if FILENAME is an accessible directory.
+Delegates to `file-directory-p' - remote dirs are always readable."
+  (remoto--handle-file-directory-p filename))
 
 (defun remoto--handle-file-regular-p (filename)
   "Return t if FILENAME is a regular file in the remote repo."
@@ -549,9 +569,9 @@ Handles three levels: user search at /github:, repo listing at
         ('owner
          ;; Repo completion at /github:OWNER/
          (let ((owner (plist-get partial :owner)))
-           (when-let* ((repos (remoto--fetch-user-repos owner)))
-             (seq-filter (lambda (r) (string-prefix-p file r))
-                         repos))))
+           (if (string-empty-p file)
+               (remoto--recent-owner-repos owner)
+             (remoto--search-owner-repos owner file))))
         ('repo
          ;; Branch completion at /github:OWNER/REPO@
          (if (string-suffix-p ":" file)
@@ -577,14 +597,19 @@ Handles three levels: user search at /github:, repo listing at
 
 (defun remoto--handle-file-name-completion (file directory &optional predicate)
   "Complete FILE in remote DIRECTORY using optional PREDICATE.
-Handles partial /github: paths for pre-repo completion."
-  (let ((completions (remoto--handle-file-name-all-completions file directory)))
+Handles partial /github: paths for pre-repo completion.
+PREDICATE may be a function, nil, or a string directory-prefix
+passed through by `completion-file-name-table' - strings are
+ignored since remoto paths always qualify."
+  (let ((completions (remoto--handle-file-name-all-completions file directory))
+        ;; completion-file-name-table passes the read-file-name
+        ;; directory as a string predicate - not a callable filter
+        (pred (if (stringp predicate) nil predicate)))
     (cond
      ((null completions) nil)
      ((null (cdr completions))
-      ;; Single match - return t for exact match, the string otherwise
       (if (equal file (car completions)) t (car completions)))
-     (t (try-completion file completions predicate)))))
+     (t (try-completion file completions pred)))))
 
 (defun remoto--handle-expand-file-name (name &optional dir)
   "Expand NAME relative to DIR for remoto paths."
@@ -1150,6 +1175,58 @@ Uses client-side narrowing when a parent query is cached."
                     results)
                 (user-error nil)))))))))
 
+(defun remoto--recent-owner-repos (owner)
+  "Fetch recently-updated repos for OWNER, cached with TTL.
+Returns up to 30 repo name strings, sorted by last push."
+  (let* ((cache-key (format "\0repos-recent:%s" (downcase owner))))
+    (pcase-let ((`(,hit ,results) (remoto--search-cache-get cache-key)))
+      (if hit results
+        (condition-case nil
+            (let* ((q (url-hexify-string (format "user:%s" owner)))
+                   (endpoint (format "search/repositories?q=%s&sort=updated&per_page=30" q))
+                   (items (alist-get 'items (remoto--api endpoint)))
+                   (repos (mapcar (lambda (item) (alist-get 'name item))
+                                  items)))
+              (remoto--search-cache-put cache-key repos))
+          (user-error nil))))))
+
+(defun remoto--search-owner-repos (owner query)
+  "Search OWNER's repos matching QUERY via GitHub search API.
+Returns repo names. Requires at least 2 characters in QUERY.
+Uses client-side narrowing when a parent query is cached."
+  (when (<= 2 (length query))
+    (let* ((owner-down (downcase owner))
+           (query-down (downcase query))
+           (cache-key (format "\0repos:%s/%s" owner-down query-down)))
+      (pcase-let ((`(,hit ,results) (remoto--search-cache-get cache-key)))
+        (if hit results
+          ;; Try narrowing from a shorter cached query for same owner
+          (let ((narrowed
+                 (cl-loop for len from (1- (length query-down)) downto 2
+                          for prefix = (substring query-down 0 len)
+                          for pk = (format "\0repos:%s/%s" owner-down prefix)
+                          for entry = (gethash pk remoto--search-cache)
+                          when (and entry
+                                    (or (zerop remoto-search-cache-ttl)
+                                        (< (- (float-time) (car entry))
+                                           remoto-search-cache-ttl)))
+                          return (seq-filter
+                                  (lambda (r)
+                                    (string-search query-down (downcase r)))
+                                  (cdr entry)))))
+            (if narrowed
+                (remoto--search-cache-put cache-key narrowed)
+              ;; Fetch from API
+              (condition-case nil
+                  (let* ((q (url-hexify-string
+                            (format "%s in:name user:%s" query owner)))
+                         (endpoint (format "search/repositories?q=%s&per_page=100" q))
+                         (items (alist-get 'items (remoto--api endpoint)))
+                         (repos (mapcar (lambda (item) (alist-get 'name item))
+                                        items)))
+                    (remoto--search-cache-put cache-key repos))
+                (user-error nil)))))))))
+
 (defun remoto--get-authenticated-user ()
   "Return the GitHub login of the authenticated user, or nil.
 Caches the result for the session.  Returns nil when auth has
@@ -1161,38 +1238,6 @@ failed or the API call errors."
                         (login (alist-get 'login data)))
               (setq remoto--authenticated-user login))
           (user-error nil)))))
-
-(defun remoto--fetch-user-repos (owner)
-  "Fetch repo names for OWNER, cached with TTL.
-Returns a list of repo name strings (not full_name).
-When OWNER matches the authenticated user, uses the /user/repos
-endpoint which includes private repositories."
-  (let* ((key (downcase owner))
-         (entry (gethash key remoto--user-repos-cache))
-         (now (float-time)))
-    (if (and entry
-             (or (zerop remoto-search-cache-ttl)
-                 (< (- now (car entry)) remoto-search-cache-ttl)))
-        (cdr entry)
-      (condition-case nil
-          (let* ((self (remoto--get-authenticated-user))
-                 (selfp (and self (string-equal-ignore-case key self)))
-                 (auth-uncertain (and (not self) (not remoto--auth-failed)))
-                 (endpoint (if selfp
-                               "user/repos?per_page=100&sort=updated&type=owner"
-                             (format "users/%s/repos?per_page=100&sort=updated"
-                                     (url-hexify-string owner))))
-                 (data (remoto--api endpoint))
-                 (repos (mapcar (lambda (item) (alist-get 'name item)) data)))
-            ;; Don't cache when auth state is uncertain (e.g. GPG
-            ;; timeout on first call).  We may have fallen back to
-            ;; the public endpoint for what is actually the
-            ;; authenticated user - caching would poison results
-            ;; until TTL expires.
-            (unless auth-uncertain
-              (puthash key (cons now repos) remoto--user-repos-cache))
-            repos)
-        (user-error nil)))))
 
 (defun remoto--complete-branches (query at-pos)
   "Complete branch names for QUERY with @ at AT-POS.
@@ -1416,6 +1461,42 @@ repo listings."
   (push (cons remoto--handler-regexp #'remoto-file-name-handler)
         file-name-handler-alist))
 
+(defun remoto--read-file-name-internal-a (orig string pred action)
+  "Fix completion for /github: paths inside `read-file-name'.
+Re-attaches the raw prefix that `substitute-in-file-name' strips,
+so completion frameworks (Vertico, etc.) can match candidates
+against the actual minibuffer content."
+  (let ((effective (substitute-in-file-name string)))
+    (cond
+     ;; Non-github path - pass through.
+     ((not (string-prefix-p "/github:" effective))
+      (funcall orig string pred action))
+     ;; Non-standard action (metadata, boundaries, etc.) - pass
+     ;; through with the original string so internal quoting works.
+     ((not (memq action '(nil t lambda)))
+      (funcall orig string pred action))
+     ;; Standard completion action - fixup prefixes.
+     (t
+      (let* ((gh-pos (string-search "/github:" string))
+             (raw-prefix (if (and gh-pos (< 0 gh-pos))
+                             (substring string 0 gh-pos)
+                           ""))
+             (result (funcall orig effective pred action)))
+        (pcase action
+          ('t
+           (let ((full-prefix (concat raw-prefix
+                                      (or (file-name-directory effective) ""))))
+             (mapcar (lambda (c) (concat full-prefix c)) result)))
+          ('nil
+           (cond
+            ((eq result t) t)
+            ((stringp result) (concat raw-prefix result))
+            (t result)))
+          ('lambda result)))))))
+
+(advice-add 'read-file-name-internal :around
+            #'remoto--read-file-name-internal-a)
+
 ;;;; Unload
 
 (defun remoto-unload-function ()
@@ -1424,8 +1505,8 @@ repo listings."
         (assoc-delete-all remoto--handler-regexp file-name-handler-alist))
   (advice-remove 'dired #'remoto--dired-around-a)
   (advice-remove 'find-file-noselect #'remoto--find-file-around-a)
+  (advice-remove 'read-file-name-internal #'remoto--read-file-name-internal-a)
   (clrhash remoto--users-cache)
-  (clrhash remoto--user-repos-cache)
   nil)
 
 (provide 'remoto)

--- a/remoto.el
+++ b/remoto.el
@@ -628,11 +628,13 @@ ignored since remoto paths always qualify."
       (expand-file-name name))
      ;; Relative path under a remoto directory
      ((and dir (string-prefix-p "/github:" dir))
-      (let* ((prefix (remoto--file-name-prefix dir))
-             (parsed (remoto--parse-path dir))
-             (dir-path (remoto-path-path parsed))
-             (combined (concat dir-path "/" name)))
-        (concat prefix (remoto--normalize-path combined))))
+      (if-let* ((parsed (remoto--parse-path dir))
+                (prefix (remoto--file-name-prefix dir)))
+          (let* ((dir-path (remoto-path-path parsed))
+                 (combined (concat dir-path "/" name)))
+            (concat prefix (remoto--normalize-path combined)))
+        ;; Partial path (e.g. /github:owner/ or /github:owner/repo@)
+        (concat dir name)))
      ;; Not our path, delegate
      (t (expand-file-name name dir)))))
 

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -1114,6 +1114,12 @@
     (let ((completions (remoto--handle-file-name-all-completions "torv" "/github:")))
       (expect completions :to-equal '("torvalds/"))))
 
+  (it "schedules pre-fetch for top user match"
+    (spy-on 'remoto--search-users :and-return-value '("torvalds" "torgeirhelge"))
+    (spy-on 'remoto--prefetch-owner-repos)
+    (remoto--handle-file-name-all-completions "tor" "/github:")
+    (expect 'remoto--prefetch-owner-repos :to-have-been-called-with "torvalds"))
+
   (it "returns nil for empty user query"
     (let ((completions (remoto--handle-file-name-all-completions "" "/github:")))
       (expect completions :to-be nil)))

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -39,7 +39,6 @@
          (remoto--branches-cache (make-hash-table :test 'equal))
          (remoto--search-cache (make-hash-table :test 'equal))
          (remoto--users-cache (make-hash-table :test 'equal))
-         (remoto--user-repos-cache (make-hash-table :test 'equal))
          (remoto--authenticated-user nil))
      (puthash "testowner/testrepo" "main" remoto--default-branch-cache)
      (remoto-test--install-mock-tree)
@@ -943,36 +942,49 @@
           (remoto--users-cache (make-hash-table :test 'equal)))
       (expect (remoto--search-users "tor") :to-be nil))))
 
-;;; User repos
+;;; Owner repo search
 
-(describe "remoto--fetch-user-repos"
-  (it "fetches repo names from API"
+(describe "remoto--search-owner-repos"
+  (it "returns nil for short queries"
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (expect (remoto--search-owner-repos "torvalds" "") :to-be nil)
+      (expect (remoto--search-owner-repos "torvalds" "l") :to-be nil)))
+
+  (it "searches repos via API"
     (spy-on 'remoto--api :and-return-value
-            '(((name . "linux") (full_name . "torvalds/linux"))
-              ((name . "subsurface") (full_name . "torvalds/subsurface"))))
-    (let ((remoto--user-repos-cache (make-hash-table :test 'equal))
-          (remoto--auth-failed t))
-      (expect (remoto--fetch-user-repos "torvalds")
-              :to-equal '("linux" "subsurface"))))
+            '((items . (((name . "linux"))
+                        ((name . "libfdt"))))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (let ((result (remoto--search-owner-repos "torvalds" "lin")))
+        (expect result :to-equal '("linux" "libfdt"))
+        (expect 'remoto--api :to-have-been-called)
+        (let ((call-args (spy-calls-args-for 'remoto--api 0)))
+          (expect (car call-args) :to-match "user%3Atorvalds")
+          (expect (car call-args) :to-match "lin")))))
 
   (it "caches results"
-    (let ((remoto--user-repos-cache (make-hash-table :test 'equal))
-          (remoto--auth-failed t)
+    (let ((remoto--search-cache (make-hash-table :test 'equal))
           (call-count 0))
       (spy-on 'remoto--api :and-call-fake
               (lambda (_endpoint)
                 (setq call-count (1+ call-count))
-                '(((name . "linux")))))
-      (remoto--fetch-user-repos "torvalds")
-      (remoto--fetch-user-repos "torvalds")
+                '((items . (((name . "linux")))))))
+      (remoto--search-owner-repos "torvalds" "lin")
+      (remoto--search-owner-repos "torvalds" "lin")
       (expect call-count :to-equal 1)))
 
-  (it "returns nil on API errors"
-    (spy-on 'remoto--api :and-call-fake
-            (lambda (_) (user-error "not found")))
-    (let ((remoto--user-repos-cache (make-hash-table :test 'equal))
-          (remoto--auth-failed t))
-      (expect (remoto--fetch-user-repos "nouser") :to-be nil))))
+  (it "narrows cached results for longer query"
+    (let ((remoto--search-cache (make-hash-table :test 'equal))
+          (call-count 0))
+      (spy-on 'remoto--api :and-call-fake
+              (lambda (_endpoint)
+                (setq call-count (1+ call-count))
+                '((items . (((name . "linux"))
+                            ((name . "libfdt")))))))
+      (remoto--search-owner-repos "torvalds" "li")
+      (let ((result (remoto--search-owner-repos "torvalds" "lin")))
+        (expect result :to-equal '("linux"))
+        (expect call-count :to-equal 1)))))
 
 (describe "remoto--get-authenticated-user"
   (it "returns login from /user endpoint"
@@ -1007,56 +1019,6 @@
               (lambda (_) (user-error "auth failed")))
       (expect (remoto--get-authenticated-user) :to-be nil))))
 
-(describe "remoto--fetch-user-repos with authenticated user"
-  (it "uses /user/repos endpoint for authenticated user's own repos"
-    (let ((remoto--user-repos-cache (make-hash-table :test 'equal))
-          (remoto--authenticated-user "torvalds")
-          (remoto--auth-failed nil)
-          (endpoint-called nil))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (ep)
-                (setq endpoint-called ep)
-                '(((name . "linux") (full_name . "torvalds/linux"))
-                  ((name . "private-proj") (full_name . "torvalds/private-proj")))))
-      (remoto--fetch-user-repos "torvalds")
-      (expect endpoint-called :to-equal "user/repos?per_page=100&sort=updated&type=owner")))
-
-  (it "uses /user/repos endpoint case-insensitively"
-    (let ((remoto--user-repos-cache (make-hash-table :test 'equal))
-          (remoto--authenticated-user "Torvalds")
-          (remoto--auth-failed nil)
-          (endpoint-called nil))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (ep)
-                (setq endpoint-called ep)
-                '(((name . "linux")))))
-      (remoto--fetch-user-repos "torvalds")
-      (expect endpoint-called :to-equal "user/repos?per_page=100&sort=updated&type=owner")))
-
-  (it "uses /users/{owner}/repos for other users"
-    (let ((remoto--user-repos-cache (make-hash-table :test 'equal))
-          (remoto--authenticated-user "agzam")
-          (remoto--auth-failed nil)
-          (endpoint-called nil))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (ep)
-                (setq endpoint-called ep)
-                '(((name . "linux")))))
-      (remoto--fetch-user-repos "torvalds")
-      (expect endpoint-called :to-equal "users/torvalds/repos?per_page=100&sort=updated")))
-
-  (it "skips self-detection when auth has failed"
-    (let ((remoto--user-repos-cache (make-hash-table :test 'equal))
-          (remoto--authenticated-user nil)
-          (remoto--auth-failed t)
-          (endpoint-called nil))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (ep)
-                (setq endpoint-called ep)
-                '(((name . "linux")))))
-      (remoto--fetch-user-repos "torvalds")
-      (expect endpoint-called :to-equal "users/torvalds/repos?per_page=100&sort=updated"))))
-
 (describe "remoto-reset-auth clears authenticated user"
   (it "clears cached authenticated user"
     (let ((old-auth remoto--auth-failed)
@@ -1070,94 +1032,6 @@
             (expect remoto--auth-failed :to-be nil))
         (setq remoto--auth-failed old-auth
               remoto--authenticated-user old-user)))))
-
-;;; Auth timeout resilience
-
-(describe "auth timeout does not poison session"
-  (it "retries auth on the next API call after a timeout"
-    (let ((remoto--auth-failed nil)
-          (remoto-github-auth nil)
-          (remoto-auth-timeout 0.3)
-          (call-count 0))
-      (spy-on 'ghub-get :and-call-fake
-              (lambda (_resource &optional _params &rest args)
-                (setq call-count (1+ call-count))
-                (if (eq (plist-get args :auth) 'none)
-                    '((name . "test-repo"))
-                  ;; First auth attempt times out, second succeeds
-                  (if (< call-count 3)
-                      (sleep-for 5)
-                    '((name . "test-repo"))))))
-      ;; First call: auth times out, falls back to unauthenticated
-      (remoto--api "repos/owner/repo")
-      ;; Second call: should retry auth (not skip it)
-      (let ((remoto-auth-timeout 5))
-        (remoto--api "repos/owner/repo"))
-      ;; ghub-get was called with non-none auth on the second attempt
-      (expect remoto--auth-failed :to-be nil)))
-
-  (it "does not cache repo results when auth state is uncertain"
-    (let ((remoto--user-repos-cache (make-hash-table :test 'equal))
-          (remoto--authenticated-user nil)
-          (remoto--auth-failed nil))
-      ;; Simulate: get-authenticated-user returns nil (timeout),
-      ;; but auth hasn't permanently failed
-      (spy-on 'remoto--get-authenticated-user :and-return-value nil)
-      (spy-on 'remoto--api :and-return-value
-              '(((name . "public-repo") (full_name . "agzam/public-repo"))))
-      (let ((repos (remoto--fetch-user-repos "agzam")))
-        ;; Returns results for this call
-        (expect repos :to-equal '("public-repo"))
-        ;; But does NOT cache them (auth was uncertain)
-        (expect (gethash "agzam" remoto--user-repos-cache) :to-be nil))))
-
-  (it "caches repo results when auth succeeds"
-    (let ((remoto--user-repos-cache (make-hash-table :test 'equal))
-          (remoto--authenticated-user "agzam")
-          (remoto--auth-failed nil))
-      (spy-on 'remoto--api :and-return-value
-              '(((name . "private-repo") (full_name . "agzam/private-repo"))))
-      (remoto--fetch-user-repos "agzam")
-      (expect (gethash "agzam" remoto--user-repos-cache) :to-be-truthy)))
-
-  (it "caches repo results when auth permanently failed"
-    (let ((remoto--user-repos-cache (make-hash-table :test 'equal))
-          (remoto--authenticated-user nil)
-          (remoto--auth-failed t))
-      (spy-on 'remoto--api :and-return-value
-              '(((name . "public-repo") (full_name . "agzam/public-repo"))))
-      (remoto--fetch-user-repos "agzam")
-      ;; Auth permanently failed - we know this is the public endpoint,
-      ;; safe to cache
-      (expect (gethash "agzam" remoto--user-repos-cache) :to-be-truthy)))
-
-  (it "second completion call gets private repos after GPG agent warms up"
-    (let ((remoto--user-repos-cache (make-hash-table :test 'equal))
-          (remoto--authenticated-user nil)
-          (remoto--auth-failed nil)
-          (auth-call-count 0))
-      ;; First call: get-authenticated-user fails (GPG timeout)
-      ;; Second call: succeeds (GPG agent has passphrase)
-      (spy-on 'remoto--get-authenticated-user :and-call-fake
-              (lambda ()
-                (setq auth-call-count (1+ auth-call-count))
-                (if (< auth-call-count 2)
-                    nil
-                  (setq remoto--authenticated-user "agzam")
-                  "agzam")))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (endpoint)
-                (if (string-prefix-p "user/repos" endpoint)
-                    '(((name . "private-repo")) ((name . "public-repo")))
-                  '(((name . "public-repo"))))))
-      ;; First call: no auth, public endpoint, NOT cached
-      (let ((repos1 (remoto--fetch-user-repos "agzam")))
-        (expect repos1 :to-equal '("public-repo"))
-        (expect (gethash "agzam" remoto--user-repos-cache) :to-be nil))
-      ;; Second call: auth works, private endpoint, cached
-      (let ((repos2 (remoto--fetch-user-repos "agzam")))
-        (expect repos2 :to-equal '("private-repo" "public-repo"))
-        (expect (gethash "agzam" remoto--user-repos-cache) :to-be-truthy)))))
 
 ;;; Partial path file operations - repo@ level
 
@@ -1186,10 +1060,10 @@
       (let ((users (remoto--handle-file-name-all-completions "tor" "/github:")))
         (expect users :to-equal '("torvalds/")))
 
-      ;; Step 2: /github:torvalds/ + "" -> repo completions
-      (spy-on 'remoto--fetch-user-repos :and-return-value '("linux" "subsurface"))
-      (let ((repos (remoto--handle-file-name-all-completions "" "/github:torvalds/")))
-        (expect repos :to-equal '("linux" "subsurface")))
+      ;; Step 2: /github:torvalds/ + "lin" -> repo completions
+      (spy-on 'remoto--search-owner-repos :and-return-value '("linux"))
+      (let ((repos (remoto--handle-file-name-all-completions "lin" "/github:torvalds/")))
+        (expect repos :to-equal '("linux")))
 
       ;; Step 3: verify path splitting for orderless at repo@ boundary
       (expect (remoto--handle-file-name-directory "/github:torvalds/linux@")
@@ -1208,14 +1082,13 @@
                     "s" "/github:testowner/testrepo@main:/")))
         (expect (member "src/" files) :to-be-truthy))))
 
-  (it "orderless-style: fetches all candidates then filters client-side"
-    ;; This simulates what orderless does: file-name-all-completions "" dir
-    ;; then filters the full list client-side
-    (spy-on 'remoto--fetch-user-repos :and-return-value
-            '("linux" "subsurface" "libdc-for-dirk"))
-    ;; orderless calls with empty file, gets everything
-    (let ((all (remoto--handle-file-name-all-completions "" "/github:torvalds/")))
-      (expect (length all) :to-equal 3)
+  (it "orderless-style: searches then filters client-side"
+    ;; This simulates what orderless does with the new search-based approach
+    (spy-on 'remoto--search-owner-repos :and-return-value
+            '("linux" "libdc-for-dirk"))
+    ;; orderless calls with a query, gets matching repos
+    (let ((all (remoto--handle-file-name-all-completions "li" "/github:torvalds/")))
+      (expect (length all) :to-equal 2)
       ;; Then filters client-side
       (let ((filtered (seq-filter (lambda (r) (string-prefix-p "lin" r)) all)))
         (expect filtered :to-equal '("linux"))))))
@@ -1237,13 +1110,14 @@
     (let ((completions (remoto--handle-file-name-all-completions "" "/github:")))
       (expect completions :to-be nil)))
 
-  (it "returns repo completions at /github:owner/"
-    (spy-on 'remoto--fetch-user-repos :and-return-value '("linux" "subsurface"))
+  (it "returns recent repos for empty query at /github:owner/"
+    (spy-on 'remoto--recent-owner-repos :and-return-value '("linux" "uemacs"))
     (let ((completions (remoto--handle-file-name-all-completions "" "/github:torvalds/")))
-      (expect completions :to-equal '("linux" "subsurface"))))
+      (expect completions :to-equal '("linux" "uemacs"))
+      (expect 'remoto--recent-owner-repos :to-have-been-called-with "torvalds")))
 
-  (it "filters repos by prefix"
-    (spy-on 'remoto--fetch-user-repos :and-return-value '("linux" "subsurface"))
+  (it "searches repos by query"
+    (spy-on 'remoto--search-owner-repos :and-return-value '("linux"))
     (let ((completions (remoto--handle-file-name-all-completions "lin" "/github:torvalds/")))
       (expect completions :to-equal '("linux"))))
 

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -367,6 +367,14 @@
         (expect (expand-file-name "/tmp/foo")
                 :to-equal "/tmp/foo"))))
 
+  (it "expand-file-name handles partial /github:owner/ dir"
+    (expect (expand-file-name "somerepo" "/github:owner/")
+            :to-equal "/github:owner/somerepo"))
+
+  (it "expand-file-name handles partial /github:owner/repo@ dir"
+    (expect (expand-file-name "main:" "/github:owner/repo@")
+            :to-equal "/github:owner/repo@main:"))
+
   (it "insert-file-contents does not move point"
     (remoto-test-with-cache
       (spy-on 'remoto--fetch-file-content


### PR DESCRIPTION
Replace the fetch-all-repos approach with GitHub's search API:

- Empty input at /github:owner/ shows 30 most recently updated repos
- Typing queries the search API (search/repositories?q=QUERY+user:OWNER)
- Client-side narrowing from cached results for longer queries

Fix auth timeout scoping: only apply the 2s timeout before the authenticated user is known. Once auth succeeds, skip the timeout so slow API responses are not aborted.

Fix error handling: HTTP 404/403 no longer poison remoto--auth-failed. Only actual auth-source errors trigger the unauthenticated fallback.

Add file-accessible-directory-p handler, read-file-name-internal advice for Vertico compatibility, file-exists-p for partial owner/repo paths.

Remove remoto--fetch-user-repos and remoto--user-repos-cache.