### PR TITLE
Add issue display, completion annotations, and new path levels

### DIFF
--- a/README.org
+++ b/README.org
@@ -58,17 +58,21 @@ C-x C-f https://github.com/torvalds/linux/blob/master/README RET
 
 *** find-file completion
 
-The ~/github:~ prefix enables multi-level completion directly in ~find-file~ (~C-x C-f~). Type ~/github:~ and then narrow through users, repos, branches, and files:
+The ~/github:~ prefix enables multi-level completion directly in ~find-file~ (~C-x C-f~). Three delimiters after ~owner/repo~ control the mode: ~/~ for files, ~@~ for branches/tags, ~#~ for issues/PRs.
 
 #+begin_example
-/github:tor         -> users/orgs matching "tor" (torvalds/, torgeirhelge/, ...)
-/github:torvalds/   -> repos (linux, subsurface, ...)
-/github:torvalds/lin -> filters repos starting with "lin"
-/github:torvalds/linux@        -> branches (master, ...)
-/github:torvalds/linux@master: -> file-level completion within the repo
+/github:              -> your user + orgs (when authenticated)
+/github:tor           -> users/orgs matching "tor"
+/github:torvalds/     -> repos (with descriptions)
+/github:torvalds/linux/        -> files on default branch (with last commit messages)
+/github:torvalds/linux@        -> branches + tags (grouped)
+/github:torvalds/linux@master: -> file-level completion
+/github:torvalds/linux#        -> issues + PRs (with titles, PRs first)
 #+end_example
 
-Hitting RET on ~/github:owner/repo~ (without ~@branch~) opens the repo with its default branch. User search requires at least 2 characters.
+Each level shows annotations: repo descriptions, issue/PR titles and state, file commit messages, user/org type. Works with vanilla completion, Vertico, Corfu, etc.
+
+Hitting RET on ~/github:owner/repo~ opens the default branch. ~/github:owner/repo#42~ opens an issue/PR display buffer.
 
 *** Canonical paths
 
@@ -79,6 +83,12 @@ The virtual filesystem uses paths of the form:
 #+end_example
 
 ~REF~ is optional - omitting it uses the repo's default branch.
+
+*** Issue/PR display
+
+Opening ~/github:owner/repo#42~ shows a dedicated buffer with the issue or PR content. For PRs: diff stats, branch info, merge status, and review summary. For both: body + comments.
+
+Keybindings in the display buffer: ~b~ (open in browser), ~g~ (refresh).
 
 *** Commands
 
@@ -125,7 +135,7 @@ We can only imagine a world where git's transport layer gives you a browsable fi
 - Timestamps in dired are synthetic (the tree API has no timestamps).
 - Very large repos (100k+ files) use slower per-directory fetching.
 - Rate limit: 5,000 requests/hour (normal browsing stays well within this).
-- Repo completion at ~/github:owner/~ shows the 30 most recently updated repos on empty input. Typing narrows via the GitHub search API.
+- Per-file commit annotations make up to 20 API calls on first directory listing (cached after).
 
 * Changelog
 

--- a/README.org
+++ b/README.org
@@ -67,7 +67,7 @@ The ~/github:~ prefix enables multi-level completion directly in ~find-file~ (~C
 /github:torvalds/linux/        -> files on default branch (with last commit messages)
 /github:torvalds/linux@        -> branches + tags (grouped)
 /github:torvalds/linux@master: -> file-level completion
-/github:torvalds/linux#        -> issues + PRs (with titles, PRs first)
+/github:torvalds/linux#        -> issues + PRs
 #+end_example
 
 Each level shows annotations: repo descriptions, issue/PR titles and state, file commit messages, user/org type. Works with vanilla completion, Vertico, Corfu, etc.

--- a/SPEC.md
+++ b/SPEC.md
@@ -375,6 +375,10 @@ Faces: `remoto-topic-title`, `remoto-topic-state-open`, `remoto-topic-state-clos
 
 `remoto-unload-function` removes the handler-alist entry and all advice, clears all caches (tree, default-branch, branches, tags, issues, users, search, content, file-commits).
 
+## Known Technical Debt
+
+- `remoto-browse` and `find-file` completion have parallel dispatch/formatting code. The fetch logic is shared (`remoto--fetch-dir-children-light`, `remoto--fetch-branches`, `remoto--fetch-issues`, etc.), but the mode parsing (`remoto--browse-parse-input` vs `remoto--parse-partial-github-path`) and candidate formatting (full paths vs bare names) are duplicated. A shared dispatcher returning raw candidates per mode, with each UI layer applying its prefix, would eliminate this. Non-trivial because `file-name-all-completions` splits input into `(file directory)` while `completing-read` uses a single string.
+
 ## Limitations
 
 - Read-only. No commits, no pushes, no file modifications.

--- a/SPEC.md
+++ b/SPEC.md
@@ -245,6 +245,11 @@ TRAMP's `tramp-file-name-regexp` matches `/method:...` patterns, which would int
 
 ## Error Handling
 
+Two policies:
+
+1. During completion (typing/TAB): all errors swallowed, empty list returned. Every `remoto--fetch-*` uses `(condition-case nil ... (user-error nil))`.
+2. During open (RET): errors surface as `user-error` ("Remoto: not found: ...").
+
 ghub signals typed conditions for HTTP errors. `remoto--api` catches these and re-signals as `user-error`:
 
 - `ghub-404` - not found (repo missing, private without access)
@@ -262,38 +267,113 @@ ghub signals typed conditions for HTTP errors. `remoto--api` catches these and r
 
 ### find-file completion
 
-The `/github:` prefix enables multi-level completion directly in `find-file` (`C-x C-f`). This extends the file-name-handler to support pre-repo-level completions, so the standard Emacs file completion machinery drives the entire flow.
+The `/github:` prefix enables multi-level completion directly in `find-file` (`C-x C-f`). Standard Emacs file completion machinery drives the entire flow.
 
-Completion levels:
+#### Delimiter rules
 
-| Input | Directory part | File part | Action |
+The first delimiter character after `OWNER/REPO` determines the completion mode:
+
+| Delimiter | Mode | Example |
+|---|---|---|
+| `/` | files-default (browse on default branch) | `/github:owner/repo/src/` |
+| `@` | repo (pick branch or tag) | `/github:owner/repo@v1.0:` |
+| `#` | issues (browse issues/PRs) | `/github:owner/repo#42` |
+
+Once consumed, other delimiters become literal (e.g. `/github:foo/bar/@` - the `@` is a filename character).
+
+#### Completion levels
+
+| Level | Directory | Query | Action |
 |---|---|---|---|
-| `/github:tor` | `/github:` | `tor` | Search users/orgs matching "tor" via `search/users` API |
-| `/github:torvalds/` | `/github:torvalds/` | (empty) | Show 30 most recently updated repos via `search/repositories?q=user:torvalds&sort=updated` |
-| `/github:torvalds/lin` | `/github:torvalds/` | `lin` | Search repos matching "lin" via `search/repositories?q=lin+in:name+user:torvalds` |
-| `/github:torvalds/linux@` | `/github:torvalds/` | `linux@` | List branches via `repos/torvalds/linux/branches` API |
-| `/github:torvalds/linux@master:` | `/github:torvalds/linux@master:` | (empty) | File-level completion (existing tree-based) |
+| `root` | `/github:` | empty | Show authenticated user + org memberships (via `/user/orgs`) |
+| `root` | `/github:` | 2+ chars | Search users/orgs via `search/users` |
+| `owner` | `/github:OWNER/` | empty | 30 most recently updated repos |
+| `owner` | `/github:OWNER/` | 2+ chars | Search repos by name |
+| `repo` | `/github:OWNER/REPO@` | any | Branches + tags merged, `:` suffix on selection |
+| `files-default` | `/github:OWNER/REPO/[subdir/]` | any | Tree listing on default branch |
+| `issues` | `/github:OWNER/REPO#` | empty | Top 30 open issues+PRs |
+| `issues` | `/github:OWNER/REPO#` | numeric | Direct fetch + cache filter |
+| `issues` | `/github:OWNER/REPO#` | text | Search via `search/issues` |
+| canonical | `/github:OWNER/REPO@REF:/path/` | any | Tree listing at path |
 
-Hitting RET on `/github:owner/repo` (without `@ref:`) resolves the default branch via `remoto--maybe-rewrite` and opens `/github:owner/repo@default:/` in dired.
+#### Annotations (affixation-function)
 
-New API functions:
+Each level provides annotations via completion metadata `affixation-function`. Alignment uses `(space :align-to N)` display property. All annotations get `remoto-annotation` face.
 
-- `remoto--search-users` - calls `search/users?q=PREFIX&per_page=30`. Caches results in `remoto--users-cache` (TTL-based, same as `remoto-search-cache-ttl`). Supports client-side narrowing: typing "torv" filters cached "tor" results without a new API call. Requires min 2 characters.
-- `remoto--recent-owner-repos` - calls `search/repositories?q=user:OWNER&sort=updated&per_page=30`. Returns the 30 most recently pushed repos for an owner. Used when the input is empty at `/github:OWNER/`.
-- `remoto--search-owner-repos` - calls `search/repositories?q=QUERY+in:name+user:OWNER&per_page=100`. Searches repos by name within an owner. Supports client-side narrowing from cached shorter queries. Requires min 2 characters.
+| Level | Annotation |
+|---|---|
+| root | User/Organization type + org description |
+| owner | Repository description |
+| repo | group-function: "Branch" vs "Tag" |
+| files-default, canonical | Last commit message per file (up to 20 API calls, cached) |
+| issues | PR/Issue prefix + title + state; group-function: "Pull Request" vs "Issue" |
 
-New caches:
+PRs are sorted before issues. Completion category is set to `remoto` (with `partial-completion` style) to prevent Marginalia from overriding.
 
-- `remoto--users-cache` - hash table: query string -> `(TIMESTAMP . USER-NAMES)`.
-- `remoto--search-cache` - unified cache: key string -> `(TIMESTAMP . RESULTS)`. Used for user search (`\0users:PREFIX`), recent repos (`\0repos-recent:OWNER`), and repo search (`\0repos:OWNER/QUERY`).
+#### Path normalization on RET
 
-Partial path handling:
+| Short form | Normalized to |
+|---|---|
+| `/github:owner/repo/` | `/github:owner/repo@DEFAULTBRANCH:/` |
+| `/github:owner/repo/src/main.el` | `/github:owner/repo@DEFAULTBRANCH:/src/main.el` |
+| `/github:owner/repo#42` | Routed to `remoto-topic-display` (no file operation) |
 
-The file-name handler now recognizes partial paths (`/github:`, `/github:OWNER/`) that don't match `remoto--path-regexp`. For these paths, `file-exists-p` and `file-directory-p` return t (they are virtual completion directories), `file-name-directory` and `file-name-nondirectory` split correctly (e.g., `/github:foo` splits to directory `/github:` and nondirectory `foo`), and `file-remote-p` returns `/github:` as the remote prefix. `remoto--parse-partial-canonical` handles the intermediate form `/github:OWNER/REPO[@REF]` (without trailing `:`), converting it to a canonical path for opening.
+The `#NUM` interception happens in `remoto--find-file-around-a` BEFORE `remoto--maybe-rewrite` (rewrite would mangle the `#` delimiter).
+
+#### file-exists-p RET guard
+
+Returns nil for incomplete paths (triggers `[Confirm]` prompt):
+
+| Returns t | Returns nil |
+|---|---|
+| `/github:`, `/github:owner/`, `/github:owner/repo/`, `/github:owner/repo#42`, canonical paths in tree | `/github:owner/repo` (bare), `/github:owner/repo#`, `/github:owner/repo@`, `/github:owner#` |
+
+#### API functions
+
+- `remoto--search-users` - `search/users`. Cached, client-side narrowing from parent queries. Min 2 chars.
+- `remoto--recent-owner-repos` - `search/repositories?q=user:OWNER&sort=updated`. Cached.
+- `remoto--search-owner-repos` - `search/repositories?q=QUERY+in:name+user:OWNER`. Cached, client-side narrowing.
+- `remoto--fetch-branches` - `repos/OWNER/REPO/branches`. TTL-cached in `remoto--branches-cache`.
+- `remoto--fetch-tags` - `repos/OWNER/REPO/tags`. TTL-cached in `remoto--tags-cache`.
+- `remoto--fetch-issues` - `repos/OWNER/REPO/issues?state=open&sort=updated`. TTL-cached in `remoto--issues-cache`.
+- `remoto--search-issues` - `search/issues?q=QUERY+repo:OWNER/REPO`. Not cached (ephemeral).
+- `remoto--fetch-issue` - `repos/OWNER/REPO/issues/NUMBER`. Not cached.
+- `remoto--fetch-user-orgs` - `/user/orgs` (authenticated endpoint, includes private memberships).
+- `remoto--fetch-file-commits` - `repos/OWNER/REPO/commits?sha=REF&path=FILE&per_page=1` per file (capped at 20). TTL-cached in `remoto--file-commits-cache`.
+
+#### Caches
+
+| Variable | Key | Value | TTL |
+|---|---|---|---|
+| `remoto--tree-cache` | `"owner/repo@ref"` | hash-table (path -> entry) | Manual |
+| `remoto--default-branch-cache` | `"owner/repo"` | branch name string | Manual |
+| `remoto--branches-cache` | `"owner/repo"` | `(TIMESTAMP . LIST)` | `remoto-search-cache-ttl` |
+| `remoto--tags-cache` | `"owner/repo"` | `(TIMESTAMP . LIST)` | `remoto-search-cache-ttl` |
+| `remoto--issues-cache` | `"owner/repo"` | `(TIMESTAMP . ALIST)` | `remoto-search-cache-ttl` |
+| `remoto--users-cache` | query string | `(TIMESTAMP . NAMES)` | `remoto-search-cache-ttl` |
+| `remoto--search-cache` | typed key | `(TIMESTAMP . RESULTS)` | `remoto-search-cache-ttl` |
+| `remoto--content-cache` | SHA | decoded string | Never (content-addressable) |
+| `remoto--file-commits-cache` | `"owner/repo@ref:dir"` | `(TIMESTAMP . ALIST)` | `remoto-search-cache-ttl` |
+
+#### Partial path handling
+
+The handler recognizes partial paths (`/github:`, `/github:OWNER/`) that don't match `remoto--path-regexp`. For these: `file-exists-p` and `file-directory-p` return t, `file-name-directory`/`nondirectory` split correctly, `file-remote-p` returns `/github:` prefix. `remoto--parse-partial-canonical` handles `/github:OWNER/REPO[@REF]` (excludes `#` from repo name character class).
+
+## Topic Display (remoto-topic.el)
+
+Opening `/github:owner/repo#NUM` via `find-file` routes to `remoto-topic-display` instead of file operations. Detects whether the number is an issue or PR and renders accordingly.
+
+For PRs: fetches full PR data (`repos/OWNER/REPO/pulls/NUM`) for diff stats, branch info, merge state, and review summary (`repos/OWNER/REPO/pulls/NUM/reviews`).
+
+For both: fetches comments (`repos/OWNER/REPO/issues/NUM/comments`).
+
+Buffer name: `*remoto: owner/repo#NUM*`. Mode: `remoto-topic-mode` (derived from `special-mode`). Keybindings: `b` (browse URL), `g` (refresh). Carriage returns stripped from body/comments.
+
+Faces: `remoto-topic-title`, `remoto-topic-state-open`, `remoto-topic-state-closed`, `remoto-topic-state-merged`, `remoto-topic-meta`, `remoto-topic-comment-header`, `remoto-topic-additions`, `remoto-topic-deletions`.
 
 ## Unloading
 
-`remoto-unload-function` removes the `file-name-handler-alist` entry and all advice, and clears `remoto--users-cache`, ensuring clean `unload-feature` support.
+`remoto-unload-function` removes the handler-alist entry and all advice, clears all caches (tree, default-branch, branches, tags, issues, users, search, content, file-commits).
 
 ## Limitations
 
@@ -367,7 +447,8 @@ Each prefix would have its own entry in `file-name-handler-alist`, dispatching t
 
 ```
 remoto.el/
-  remoto.el          ;; the package - single file
+  remoto.el          ;; core: file-name-handler, completion, API, caching
+  remoto-topic.el    ;; issue/PR display buffers
   SPEC.md            ;; this spec
   README.org         ;; user-facing documentation
   CHANGELOG.org      ;; release history

--- a/changelog.org
+++ b/changelog.org
@@ -3,6 +3,33 @@
 
 Changes to the project, following Keep a Changelog conventions.
 
+* [1.4.0] - 2026-05-06
+
+** Added
+- Three new completion levels: files-default (~/github:o/r/~), issues (~/github:o/r#~), branches+tags (~/github:o/r@~).
+- Root level (~/github:~) shows authenticated user + org memberships when query is empty.
+- ~remoto-topic.el~ - dedicated issue/PR display buffers. PR-aware rendering with diff stats, branch info, merge state, and review summary.
+- Completion annotations at every level via ~affixation-function~: repo descriptions, issue/PR titles, branch/tag grouping, user/org type, per-file last commit messages.
+- ~remoto--fetch-tags~ for tag completion at the ~@~ level.
+- ~remoto--fetch-issues~, ~remoto--search-issues~, ~remoto--fetch-issue~ for ~#~ level.
+- ~remoto--fetch-issue-comments~ for topic display.
+- ~remoto--fetch-file-commits~ for per-file commit message annotations (capped at 20 per directory).
+- ~remoto--fetch-user-orgs~ using authenticated ~/user/orgs~ endpoint.
+- ~remoto-annotation~ face (inherits ~completions-annotations~).
+- Annotation alignment via ~(space :align-to N)~ display property.
+- ~remoto-topic-mode~ (derived from ~special-mode~) with ~b~ (browse) and ~g~ (refresh) keybindings.
+
+** Changed
+- Completion category set to ~remoto~ (with ~partial-completion~ style) when annotations are active, preventing Marginalia from overriding.
+- PRs sorted before issues in ~#~ completion.
+- ~remoto--parse-partial-canonical~ excludes ~#~ from owner/repo character class.
+- ~remoto-unload-function~ now clears all 9 caches.
+
+** Fixed
+- ~find-file-noselect~ on ~/github:o/r#42~ now correctly routes to topic display instead of treating ~#42~ as part of the repo name.
+- ~remoto--maybe-rewrite~ no longer mangles ~#NUM~ paths.
+- Carriage returns (~^M~) stripped from issue/PR body and comments.
+
 * [1.3.0] - 2026-04-28
 
 ** Changed

--- a/remoto-issue.el
+++ b/remoto-issue.el
@@ -1,0 +1,308 @@
+;;; remoto-issue.el --- Issue and PR display for remoto -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 Ag Ibragimov
+;; Author: Ag Ibragimov
+
+;; This file is NOT part of GNU Emacs.
+
+;;; Commentary:
+
+;; Dedicated buffers for viewing GitHub issues and pull requests.
+;; Provides `remoto-issue-display' for issues and `remoto-pr-display'
+;; for pull requests, with rich rendering including comments, diff
+;; stats, review state, and merge status.
+
+;;; Code:
+
+(require 'remoto)
+
+(declare-function remoto--api "remoto" (endpoint &rest args))
+(declare-function remoto--fetch-issue "remoto" (owner repo number))
+(declare-function remoto--fetch-issue-comments "remoto" (owner repo number))
+
+;;;; Customization
+
+(defgroup remoto-issue nil
+  "GitHub issue and PR display for remoto."
+  :group 'remoto
+  :prefix "remoto-issue-")
+
+(defface remoto-issue-title
+  '((t :weight bold :height 1.2))
+  "Face for issue/PR title.")
+
+(defface remoto-issue-state-open
+  '((t :foreground "green"))
+  "Face for open state.")
+
+(defface remoto-issue-state-closed
+  '((t :foreground "red"))
+  "Face for closed state.")
+
+(defface remoto-issue-state-merged
+  '((t :foreground "purple"))
+  "Face for merged state.")
+
+(defface remoto-issue-meta
+  '((t :foreground "gray"))
+  "Face for metadata (author, date, labels).")
+
+(defface remoto-issue-separator
+  '((t :foreground "gray" :strike-through t))
+  "Face for horizontal separators.")
+
+(defface remoto-issue-comment-header
+  '((t :weight bold))
+  "Face for comment author/date header.")
+
+(defface remoto-issue-additions
+  '((t :foreground "green"))
+  "Face for addition count in PR stats.")
+
+(defface remoto-issue-deletions
+  '((t :foreground "red"))
+  "Face for deletion count in PR stats.")
+
+;;;; Buffer-local state
+
+(defvar-local remoto-issue--number nil
+  "Issue/PR number displayed in this buffer.")
+
+(defvar-local remoto-issue--repo-path nil
+  "Repo path (e.g. \"/github:owner/repo\") for this buffer.")
+
+(defvar-local remoto-issue--is-pr nil
+  "Non-nil if this buffer displays a pull request.")
+
+(defvar-local remoto-issue--data nil
+  "Raw issue/PR alist for the current buffer.")
+
+;;;; Mode
+
+(defvar remoto-issue-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "b" #'remoto-issue-browse)
+    (define-key map "g" #'remoto-issue-refresh)
+    map)
+  "Keymap for `remoto-issue-mode'.")
+
+(define-derived-mode remoto-issue-mode special-mode "Remoto-Issue"
+  "Major mode for viewing GitHub issues and pull requests.
+
+\\{remoto-issue-mode-map}"
+  :group 'remoto-issue)
+
+;;;; Commands
+
+(defun remoto-issue-browse ()
+  "Open the current issue/PR in a web browser."
+  (interactive)
+  (when-let* ((number remoto-issue--number)
+              (path remoto-issue--repo-path)
+              (_ (string-match (rx "/github:" (group (+ nonl))) path))
+              (slug (match-string 1 path))
+              (type (if remoto-issue--is-pr "pull" "issues")))
+    (browse-url (format "https://github.com/%s/%s/%s" slug type number))))
+
+(defun remoto-issue-refresh ()
+  "Re-fetch and redisplay the current issue/PR."
+  (interactive)
+  (when (and remoto-issue--number remoto-issue--repo-path)
+    (remoto-issue-display remoto-issue--number remoto-issue--repo-path)))
+
+;;;; Formatting helpers
+
+(defun remoto-issue--format-date (date-str)
+  "Format DATE-STR (ISO 8601) to YYYY-MM-DD."
+  (if (and date-str
+           (string-match (rx bos (group (= 4 digit) "-" (= 2 digit) "-" (= 2 digit)))
+                         date-str))
+      (match-string 1 date-str)
+    (or date-str "")))
+
+(defun remoto-issue--state-face (state merged)
+  "Return face for STATE, accounting for MERGED status."
+  (cond
+   (merged 'remoto-issue-state-merged)
+   ((equal state "open") 'remoto-issue-state-open)
+   (t 'remoto-issue-state-closed)))
+
+(defun remoto-issue--separator ()
+  "Insert a visual separator line."
+  (insert (propertize (make-string 60 ?-) 'face 'remoto-issue-separator) "\n"))
+
+;;;; PR-specific data fetching
+
+(defun remoto-issue--fetch-pr (owner repo number)
+  "Fetch full PR data for NUMBER in OWNER/REPO.
+Returns PR alist with merge status, diff stats, review state."
+  (condition-case nil
+      (remoto--api (format "repos/%s/%s/pulls/%s" owner repo number))
+    (user-error nil)))
+
+(defun remoto-issue--fetch-reviews (owner repo number)
+  "Fetch reviews for PR NUMBER in OWNER/REPO."
+  (condition-case nil
+      (remoto--api (format "repos/%s/%s/pulls/%s/reviews" owner repo number))
+    (user-error nil)))
+
+;;;; Rendering
+
+(defun remoto-issue--render-header (data is-pr)
+  "Render the header section for DATA. IS-PR if pull request."
+  (let* ((number (alist-get 'number data))
+         (title (or (alist-get 'title data) ""))
+         (state (or (alist-get 'state data) "unknown"))
+         (merged (and is-pr (alist-get 'merged data)))
+         (draft (and is-pr (alist-get 'draft data)))
+         (user (alist-get 'user data))
+         (author (or (and user (alist-get 'login user)) "unknown"))
+         (labels (alist-get 'labels data))
+         (label-names (mapcar (lambda (l) (alist-get 'name l)) labels))
+         (created (remoto-issue--format-date (alist-get 'created_at data)))
+         (state-str (cond (merged "merged")
+                          (draft "draft")
+                          (t state)))
+         (state-face (remoto-issue--state-face state merged)))
+    ;; Title line
+    (insert (propertize (format "#%s %s" number title) 'face 'remoto-issue-title))
+    (insert "  ")
+    (insert (propertize (format "[%s]" state-str) 'face state-face))
+    (insert "\n")
+    ;; Meta line
+    (insert (propertize
+             (concat "Author: " author
+                     (when label-names
+                       (concat " | Labels: " (string-join label-names ", ")))
+                     " | " created)
+             'face 'remoto-issue-meta))
+    (insert "\n")))
+
+(defun remoto-issue--render-pr-stats (pr-data)
+  "Render PR-specific stats from PR-DATA."
+  (let* ((additions (or (alist-get 'additions pr-data) 0))
+         (deletions (or (alist-get 'deletions pr-data) 0))
+         (changed (or (alist-get 'changed_files pr-data) 0))
+         (head-ref (or (alist-get 'ref (alist-get 'head pr-data)) "?"))
+         (base-ref (or (alist-get 'ref (alist-get 'base pr-data)) "?"))
+         (mergeable (alist-get 'mergeable_state pr-data)))
+    (insert (propertize (format "%s -> %s" head-ref base-ref) 'face 'remoto-issue-meta))
+    (insert "  ")
+    (insert (propertize (format "+%d" additions) 'face 'remoto-issue-additions))
+    (insert " ")
+    (insert (propertize (format "-%d" deletions) 'face 'remoto-issue-deletions))
+    (insert (propertize (format "  %d files" changed) 'face 'remoto-issue-meta))
+    (when mergeable
+      (insert (propertize (format "  [%s]" mergeable) 'face 'remoto-issue-meta)))
+    (insert "\n")))
+
+(defun remoto-issue--render-reviews (reviews)
+  "Render review summary from REVIEWS list."
+  (when reviews
+    ;; Deduplicate: keep only the latest review per author
+    (let ((latest (make-hash-table :test 'equal)))
+      (dolist (r reviews)
+        (let* ((user (alist-get 'user r))
+               (login (and user (alist-get 'login user)))
+               (state (alist-get 'state r)))
+          (when (and login (not (equal state "COMMENTED")))
+            (puthash login state latest))))
+      (when (< 0 (hash-table-count latest))
+        (insert (propertize "Reviews: " 'face 'remoto-issue-meta))
+        (let ((first t))
+          (maphash (lambda (login state)
+                     (unless first (insert ", "))
+                     (setq first nil)
+                     (insert (format "%s " login))
+                     (insert (propertize
+                              (pcase state
+                                ("APPROVED" "approved")
+                                ("CHANGES_REQUESTED" "changes requested")
+                                (_ (downcase state)))
+                              'face (pcase state
+                                      ("APPROVED" 'remoto-issue-state-open)
+                                      ("CHANGES_REQUESTED" 'remoto-issue-state-closed)
+                                      (_ 'remoto-issue-meta)))))
+                   latest))
+        (insert "\n")))))
+
+(defun remoto-issue--render-body (data)
+  "Render the body section from DATA."
+  (let ((body (or (alist-get 'body data) "")))
+    (insert "\n")
+    (remoto-issue--separator)
+    (insert "\n")
+    (insert body)
+    (insert "\n")))
+
+(defun remoto-issue--render-comments (comments)
+  "Render COMMENTS section."
+  (when comments
+    (insert "\n")
+    (remoto-issue--separator)
+    (insert "\n")
+    (insert (propertize "Comments" 'face 'remoto-issue-title))
+    (insert "\n\n")
+    (dolist (comment comments)
+      (let* ((user (alist-get 'user comment))
+             (author (or (and user (alist-get 'login user)) "unknown"))
+             (date (remoto-issue--format-date (alist-get 'created_at comment)))
+             (body (or (alist-get 'body comment) "")))
+        (insert (propertize (format "%s - %s" author date)
+                            'face 'remoto-issue-comment-header))
+        (insert "\n")
+        (insert body)
+        (insert "\n\n")))))
+
+;;;; Entry points
+
+(defun remoto-issue--parse-repo-path (repo-path)
+  "Extract owner and repo from REPO-PATH.
+Returns (OWNER . REPO) or nil."
+  (when (string-match (rx "/github:" (group (+ (not (any "/@#"))))
+                          "/" (group (+ (not (any "/@#")))))
+                      repo-path)
+    (cons (match-string 1 repo-path)
+          (match-string 2 repo-path))))
+
+(defun remoto-issue-display (number repo-path)
+  "Fetch and display issue/PR NUMBER for the repo at REPO-PATH.
+REPO-PATH is like \"/github:owner/repo\".
+Detects whether NUMBER is a PR and renders accordingly."
+  (let ((parsed (remoto-issue--parse-repo-path repo-path)))
+    (unless parsed
+      (user-error "Remoto: invalid repo path: %s" repo-path))
+    (let* ((owner (car parsed))
+           (repo (cdr parsed))
+           (issue (remoto--fetch-issue owner repo number)))
+      (unless issue
+        (user-error "Remoto: not found: %s/%s#%s" owner repo number))
+      (let* ((is-pr (not (null (alist-get 'pull_request issue))))
+             (pr-data (when is-pr
+                        (remoto-issue--fetch-pr owner repo number)))
+             (reviews (when is-pr
+                        (remoto-issue--fetch-reviews owner repo number)))
+             (comments (remoto--fetch-issue-comments owner repo number))
+             (display-data (or pr-data issue))
+             (buf-name (format "*remoto: %s/%s#%s*" owner repo number))
+             (buf (get-buffer-create buf-name)))
+        (with-current-buffer buf
+          (let ((inhibit-read-only t))
+            (erase-buffer)
+            (remoto-issue--render-header display-data is-pr)
+            (when (and is-pr pr-data)
+              (remoto-issue--render-pr-stats pr-data)
+              (remoto-issue--render-reviews reviews))
+            (remoto-issue--render-body display-data)
+            (remoto-issue--render-comments comments))
+          (goto-char (point-min))
+          (remoto-issue-mode)
+          (setq remoto-issue--number number
+                remoto-issue--repo-path repo-path
+                remoto-issue--is-pr is-pr
+                remoto-issue--data display-data))
+        (pop-to-buffer buf)
+        buf))))
+
+(provide 'remoto-issue)
+;;; remoto-issue.el ends here

--- a/remoto-issue.el
+++ b/remoto-issue.el
@@ -226,9 +226,13 @@ Returns PR alist with merge status, diff stats, review state."
                    latest))
         (insert "\n")))))
 
+(defun remoto-issue--normalize-text (text)
+  "Strip carriage returns from TEXT."
+  (string-replace "\r" "" text))
+
 (defun remoto-issue--render-body (data)
   "Render the body section from DATA."
-  (let ((body (or (alist-get 'body data) "")))
+  (let ((body (remoto-issue--normalize-text (or (alist-get 'body data) ""))))
     (insert "\n")
     (remoto-issue--separator)
     (insert "\n")
@@ -247,7 +251,7 @@ Returns PR alist with merge status, diff stats, review state."
       (let* ((user (alist-get 'user comment))
              (author (or (and user (alist-get 'login user)) "unknown"))
              (date (remoto-issue--format-date (alist-get 'created_at comment)))
-             (body (or (alist-get 'body comment) "")))
+             (body (remoto-issue--normalize-text (or (alist-get 'body comment) ""))))
         (insert (propertize (format "%s - %s" author date)
                             'face 'remoto-issue-comment-header))
         (insert "\n")

--- a/remoto-topic.el
+++ b/remoto-topic.el
@@ -1,4 +1,4 @@
-;;; remoto-issue.el --- Issue and PR display for remoto -*- lexical-binding: t; -*-
+;;; remoto-topic.el --- Issue and PR display for remoto -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2024 Ag Ibragimov
 ;; Author: Ag Ibragimov
@@ -8,7 +8,7 @@
 ;;; Commentary:
 
 ;; Dedicated buffers for viewing GitHub issues and pull requests.
-;; Provides `remoto-issue-display' for issues and `remoto-pr-display'
+;; Provides `remoto-topic-display' for issues and `remoto-pr-display'
 ;; for pull requests, with rich rendering including comments, diff
 ;; stats, review state, and merge status.
 
@@ -22,97 +22,97 @@
 
 ;;;; Customization
 
-(defgroup remoto-issue nil
+(defgroup remoto-topic nil
   "GitHub issue and PR display for remoto."
   :group 'remoto
-  :prefix "remoto-issue-")
+  :prefix "remoto-topic-")
 
-(defface remoto-issue-title
+(defface remoto-topic-title
   '((t :weight bold :height 1.2))
   "Face for issue/PR title.")
 
-(defface remoto-issue-state-open
+(defface remoto-topic-state-open
   '((t :foreground "green"))
   "Face for open state.")
 
-(defface remoto-issue-state-closed
+(defface remoto-topic-state-closed
   '((t :foreground "red"))
   "Face for closed state.")
 
-(defface remoto-issue-state-merged
+(defface remoto-topic-state-merged
   '((t :foreground "purple"))
   "Face for merged state.")
 
-(defface remoto-issue-meta
+(defface remoto-topic-meta
   '((t :foreground "gray"))
   "Face for metadata (author, date, labels).")
 
-(defface remoto-issue-separator
+(defface remoto-topic-separator
   '((t :foreground "gray" :strike-through t))
   "Face for horizontal separators.")
 
-(defface remoto-issue-comment-header
+(defface remoto-topic-comment-header
   '((t :weight bold))
   "Face for comment author/date header.")
 
-(defface remoto-issue-additions
+(defface remoto-topic-additions
   '((t :foreground "green"))
   "Face for addition count in PR stats.")
 
-(defface remoto-issue-deletions
+(defface remoto-topic-deletions
   '((t :foreground "red"))
   "Face for deletion count in PR stats.")
 
 ;;;; Buffer-local state
 
-(defvar-local remoto-issue--number nil
+(defvar-local remoto-topic--number nil
   "Issue/PR number displayed in this buffer.")
 
-(defvar-local remoto-issue--repo-path nil
+(defvar-local remoto-topic--repo-path nil
   "Repo path (e.g. \"/github:owner/repo\") for this buffer.")
 
-(defvar-local remoto-issue--is-pr nil
+(defvar-local remoto-topic--is-pr nil
   "Non-nil if this buffer displays a pull request.")
 
-(defvar-local remoto-issue--data nil
+(defvar-local remoto-topic--data nil
   "Raw issue/PR alist for the current buffer.")
 
 ;;;; Mode
 
-(defvar remoto-issue-mode-map
+(defvar remoto-topic-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map "b" #'remoto-issue-browse)
-    (define-key map "g" #'remoto-issue-refresh)
+    (define-key map "b" #'remoto-topic-browse)
+    (define-key map "g" #'remoto-topic-refresh)
     map)
-  "Keymap for `remoto-issue-mode'.")
+  "Keymap for `remoto-topic-mode'.")
 
-(define-derived-mode remoto-issue-mode special-mode "Remoto-Issue"
+(define-derived-mode remoto-topic-mode special-mode "Remoto-Issue"
   "Major mode for viewing GitHub issues and pull requests.
 
-\\{remoto-issue-mode-map}"
-  :group 'remoto-issue)
+\\{remoto-topic-mode-map}"
+  :group 'remoto-topic)
 
 ;;;; Commands
 
-(defun remoto-issue-browse ()
+(defun remoto-topic-browse ()
   "Open the current issue/PR in a web browser."
   (interactive)
-  (when-let* ((number remoto-issue--number)
-              (path remoto-issue--repo-path)
+  (when-let* ((number remoto-topic--number)
+              (path remoto-topic--repo-path)
               (_ (string-match (rx "/github:" (group (+ nonl))) path))
               (slug (match-string 1 path))
-              (type (if remoto-issue--is-pr "pull" "issues")))
+              (type (if remoto-topic--is-pr "pull" "issues")))
     (browse-url (format "https://github.com/%s/%s/%s" slug type number))))
 
-(defun remoto-issue-refresh ()
+(defun remoto-topic-refresh ()
   "Re-fetch and redisplay the current issue/PR."
   (interactive)
-  (when (and remoto-issue--number remoto-issue--repo-path)
-    (remoto-issue-display remoto-issue--number remoto-issue--repo-path)))
+  (when (and remoto-topic--number remoto-topic--repo-path)
+    (remoto-topic-display remoto-topic--number remoto-topic--repo-path)))
 
 ;;;; Formatting helpers
 
-(defun remoto-issue--format-date (date-str)
+(defun remoto-topic--format-date (date-str)
   "Format DATE-STR (ISO 8601) to YYYY-MM-DD."
   (if (and date-str
            (string-match (rx bos (group (= 4 digit) "-" (= 2 digit) "-" (= 2 digit)))
@@ -120,27 +120,27 @@
       (match-string 1 date-str)
     (or date-str "")))
 
-(defun remoto-issue--state-face (state merged)
+(defun remoto-topic--state-face (state merged)
   "Return face for STATE, accounting for MERGED status."
   (cond
-   (merged 'remoto-issue-state-merged)
-   ((equal state "open") 'remoto-issue-state-open)
-   (t 'remoto-issue-state-closed)))
+   (merged 'remoto-topic-state-merged)
+   ((equal state "open") 'remoto-topic-state-open)
+   (t 'remoto-topic-state-closed)))
 
-(defun remoto-issue--separator ()
+(defun remoto-topic--separator ()
   "Insert a visual separator line."
-  (insert (propertize (make-string 60 ?-) 'face 'remoto-issue-separator) "\n"))
+  (insert (propertize (make-string 60 ?-) 'face 'remoto-topic-separator) "\n"))
 
 ;;;; PR-specific data fetching
 
-(defun remoto-issue--fetch-pr (owner repo number)
+(defun remoto-topic--fetch-pr (owner repo number)
   "Fetch full PR data for NUMBER in OWNER/REPO.
 Returns PR alist with merge status, diff stats, review state."
   (condition-case nil
       (remoto--api (format "repos/%s/%s/pulls/%s" owner repo number))
     (user-error nil)))
 
-(defun remoto-issue--fetch-reviews (owner repo number)
+(defun remoto-topic--fetch-reviews (owner repo number)
   "Fetch reviews for PR NUMBER in OWNER/REPO."
   (condition-case nil
       (remoto--api (format "repos/%s/%s/pulls/%s/reviews" owner repo number))
@@ -148,7 +148,7 @@ Returns PR alist with merge status, diff stats, review state."
 
 ;;;; Rendering
 
-(defun remoto-issue--render-header (data is-pr)
+(defun remoto-topic--render-header (data is-pr)
   "Render the header section for DATA. IS-PR if pull request."
   (let* ((number (alist-get 'number data))
          (title (or (alist-get 'title data) ""))
@@ -159,13 +159,13 @@ Returns PR alist with merge status, diff stats, review state."
          (author (or (and user (alist-get 'login user)) "unknown"))
          (labels (alist-get 'labels data))
          (label-names (mapcar (lambda (l) (alist-get 'name l)) labels))
-         (created (remoto-issue--format-date (alist-get 'created_at data)))
+         (created (remoto-topic--format-date (alist-get 'created_at data)))
          (state-str (cond (merged "merged")
                           (draft "draft")
                           (t state)))
-         (state-face (remoto-issue--state-face state merged)))
+         (state-face (remoto-topic--state-face state merged)))
     ;; Title line
-    (insert (propertize (format "#%s %s" number title) 'face 'remoto-issue-title))
+    (insert (propertize (format "#%s %s" number title) 'face 'remoto-topic-title))
     (insert "  ")
     (insert (propertize (format "[%s]" state-str) 'face state-face))
     (insert "\n")
@@ -175,10 +175,10 @@ Returns PR alist with merge status, diff stats, review state."
                      (when label-names
                        (concat " | Labels: " (string-join label-names ", ")))
                      " | " created)
-             'face 'remoto-issue-meta))
+             'face 'remoto-topic-meta))
     (insert "\n")))
 
-(defun remoto-issue--render-pr-stats (pr-data)
+(defun remoto-topic--render-pr-stats (pr-data)
   "Render PR-specific stats from PR-DATA."
   (let* ((additions (or (alist-get 'additions pr-data) 0))
          (deletions (or (alist-get 'deletions pr-data) 0))
@@ -186,17 +186,17 @@ Returns PR alist with merge status, diff stats, review state."
          (head-ref (or (alist-get 'ref (alist-get 'head pr-data)) "?"))
          (base-ref (or (alist-get 'ref (alist-get 'base pr-data)) "?"))
          (mergeable (alist-get 'mergeable_state pr-data)))
-    (insert (propertize (format "%s -> %s" head-ref base-ref) 'face 'remoto-issue-meta))
+    (insert (propertize (format "%s -> %s" head-ref base-ref) 'face 'remoto-topic-meta))
     (insert "  ")
-    (insert (propertize (format "+%d" additions) 'face 'remoto-issue-additions))
+    (insert (propertize (format "+%d" additions) 'face 'remoto-topic-additions))
     (insert " ")
-    (insert (propertize (format "-%d" deletions) 'face 'remoto-issue-deletions))
-    (insert (propertize (format "  %d files" changed) 'face 'remoto-issue-meta))
+    (insert (propertize (format "-%d" deletions) 'face 'remoto-topic-deletions))
+    (insert (propertize (format "  %d files" changed) 'face 'remoto-topic-meta))
     (when mergeable
-      (insert (propertize (format "  [%s]" mergeable) 'face 'remoto-issue-meta)))
+      (insert (propertize (format "  [%s]" mergeable) 'face 'remoto-topic-meta)))
     (insert "\n")))
 
-(defun remoto-issue--render-reviews (reviews)
+(defun remoto-topic--render-reviews (reviews)
   "Render review summary from REVIEWS list."
   (when reviews
     ;; Deduplicate: keep only the latest review per author
@@ -208,7 +208,7 @@ Returns PR alist with merge status, diff stats, review state."
           (when (and login (not (equal state "COMMENTED")))
             (puthash login state latest))))
       (when (< 0 (hash-table-count latest))
-        (insert (propertize "Reviews: " 'face 'remoto-issue-meta))
+        (insert (propertize "Reviews: " 'face 'remoto-topic-meta))
         (let ((first t))
           (maphash (lambda (login state)
                      (unless first (insert ", "))
@@ -220,47 +220,47 @@ Returns PR alist with merge status, diff stats, review state."
                                 ("CHANGES_REQUESTED" "changes requested")
                                 (_ (downcase state)))
                               'face (pcase state
-                                      ("APPROVED" 'remoto-issue-state-open)
-                                      ("CHANGES_REQUESTED" 'remoto-issue-state-closed)
-                                      (_ 'remoto-issue-meta)))))
+                                      ("APPROVED" 'remoto-topic-state-open)
+                                      ("CHANGES_REQUESTED" 'remoto-topic-state-closed)
+                                      (_ 'remoto-topic-meta)))))
                    latest))
         (insert "\n")))))
 
-(defun remoto-issue--normalize-text (text)
-  "Strip carriage returns from TEXT."
+(defun remoto-topic--normalize-text (text)
+  "Strip carriage return from TEXT."
   (string-replace "\r" "" text))
 
-(defun remoto-issue--render-body (data)
+(defun remoto-topic--render-body (data)
   "Render the body section from DATA."
-  (let ((body (remoto-issue--normalize-text (or (alist-get 'body data) ""))))
+  (let ((body (remoto-topic--normalize-text (or (alist-get 'body data) ""))))
     (insert "\n")
-    (remoto-issue--separator)
+    (remoto-topic--separator)
     (insert "\n")
     (insert body)
     (insert "\n")))
 
-(defun remoto-issue--render-comments (comments)
+(defun remoto-topic--render-comments (comments)
   "Render COMMENTS section."
   (when comments
     (insert "\n")
-    (remoto-issue--separator)
+    (remoto-topic--separator)
     (insert "\n")
-    (insert (propertize "Comments" 'face 'remoto-issue-title))
+    (insert (propertize "Comments" 'face 'remoto-topic-title))
     (insert "\n\n")
     (dolist (comment comments)
       (let* ((user (alist-get 'user comment))
              (author (or (and user (alist-get 'login user)) "unknown"))
-             (date (remoto-issue--format-date (alist-get 'created_at comment)))
-             (body (remoto-issue--normalize-text (or (alist-get 'body comment) ""))))
+             (date (remoto-topic--format-date (alist-get 'created_at comment)))
+             (body (remoto-topic--normalize-text (or (alist-get 'body comment) ""))))
         (insert (propertize (format "%s - %s" author date)
-                            'face 'remoto-issue-comment-header))
+                            'face 'remoto-topic-comment-header))
         (insert "\n")
         (insert body)
         (insert "\n\n")))))
 
 ;;;; Entry points
 
-(defun remoto-issue--parse-repo-path (repo-path)
+(defun remoto-topic--parse-repo-path (repo-path)
   "Extract owner and repo from REPO-PATH.
 Returns (OWNER . REPO) or nil."
   (when (string-match (rx "/github:" (group (+ (not (any "/@#"))))
@@ -269,11 +269,11 @@ Returns (OWNER . REPO) or nil."
     (cons (match-string 1 repo-path)
           (match-string 2 repo-path))))
 
-(defun remoto-issue-display (number repo-path)
+(defun remoto-topic-display (number repo-path)
   "Fetch and display issue/PR NUMBER for the repo at REPO-PATH.
 REPO-PATH is like \"/github:owner/repo\".
 Detects whether NUMBER is a PR and renders accordingly."
-  (let ((parsed (remoto-issue--parse-repo-path repo-path)))
+  (let ((parsed (remoto-topic--parse-repo-path repo-path)))
     (unless parsed
       (user-error "Remoto: invalid repo path: %s" repo-path))
     (let* ((owner (car parsed))
@@ -283,9 +283,9 @@ Detects whether NUMBER is a PR and renders accordingly."
         (user-error "Remoto: not found: %s/%s#%s" owner repo number))
       (let* ((is-pr (not (null (alist-get 'pull_request issue))))
              (pr-data (when is-pr
-                        (remoto-issue--fetch-pr owner repo number)))
+                        (remoto-topic--fetch-pr owner repo number)))
              (reviews (when is-pr
-                        (remoto-issue--fetch-reviews owner repo number)))
+                        (remoto-topic--fetch-reviews owner repo number)))
              (comments (remoto--fetch-issue-comments owner repo number))
              (display-data (or pr-data issue))
              (buf-name (format "*remoto: %s/%s#%s*" owner repo number))
@@ -293,20 +293,20 @@ Detects whether NUMBER is a PR and renders accordingly."
         (with-current-buffer buf
           (let ((inhibit-read-only t))
             (erase-buffer)
-            (remoto-issue--render-header display-data is-pr)
+            (remoto-topic--render-header display-data is-pr)
             (when (and is-pr pr-data)
-              (remoto-issue--render-pr-stats pr-data)
-              (remoto-issue--render-reviews reviews))
-            (remoto-issue--render-body display-data)
-            (remoto-issue--render-comments comments))
+              (remoto-topic--render-pr-stats pr-data)
+              (remoto-topic--render-reviews reviews))
+            (remoto-topic--render-body display-data)
+            (remoto-topic--render-comments comments))
           (goto-char (point-min))
-          (remoto-issue-mode)
-          (setq remoto-issue--number number
-                remoto-issue--repo-path repo-path
-                remoto-issue--is-pr is-pr
-                remoto-issue--data display-data))
+          (remoto-topic-mode)
+          (setq remoto-topic--number number
+                remoto-topic--repo-path repo-path
+                remoto-topic--is-pr is-pr
+                remoto-topic--data display-data))
         (pop-to-buffer buf)
         buf))))
 
-(provide 'remoto-issue)
-;;; remoto-issue.el ends here
+(provide 'remoto-topic)
+;;; remoto-topic.el ends here

--- a/remoto.el
+++ b/remoto.el
@@ -327,6 +327,46 @@ On-demand fallback for repos whose recursive tree was truncated."
           (unless (gethash path tree)
             (puthash path plist tree)))))))
 
+(defvar remoto--dir-contents-cache (make-hash-table :test 'equal)
+  "Cache: \"owner/repo@ref:dir\" -> (TIMESTAMP . CHILDREN-LIST).
+Stores lightweight directory listings from Contents API.")
+
+(defun remoto--fetch-dir-children-light (owner repo ref dir-path)
+  "Fetch direct children of DIR-PATH in OWNER/REPO@REF via Contents API.
+Returns a list of (NAME . PLIST) pairs, capped at 20 entries.
+Uses cache when available. Much faster than recursive tree fetch."
+  (let* ((key (format "%s/%s@%s:%s" owner repo ref (or dir-path "")))
+         (entry (gethash key remoto--dir-contents-cache))
+         (now (float-time)))
+    (if (and entry
+             (or (zerop remoto-search-cache-ttl)
+                 (< (- now (car entry)) remoto-search-cache-ttl)))
+        (cdr entry)
+      (condition-case nil
+          (let* ((endpoint (if (or (null dir-path) (string-empty-p dir-path))
+                               (format "repos/%s/%s/contents?ref=%s"
+                                       owner repo ref)
+                             (format "repos/%s/%s/contents/%s?ref=%s"
+                                     owner repo (url-hexify-string dir-path) ref)))
+                 (data (remoto--api endpoint))
+                 (children
+                  (when (and (consp data) (consp (caar data)))
+                    (let ((result nil))
+                      (dolist (item (seq-take data 20))
+                        (let* ((name (alist-get 'name item))
+                               (api-type (alist-get 'type item))
+                               (type (if (equal api-type "dir") "tree" "blob"))
+                               (plist (list (cons 'type type)
+                                            (cons 'size (or (alist-get 'size item) 0))
+                                            (cons 'sha (or (alist-get 'sha item) ""))
+                                            (cons 'mode (if (equal type "tree")
+                                                            "040000" "100644")))))
+                          (push (cons name plist) result)))
+                      (nreverse result)))))
+            (puthash key (cons now children) remoto--dir-contents-cache)
+            children)
+        (error nil)))))
+
 (defun remoto--tree-lookup-key (path)
   "Normalize PATH for tree hash-table lookup.
 Strips leading/trailing slashes and collapses runs of slashes."
@@ -699,6 +739,8 @@ instead of blocking Emacs."
                                      (string-prefix-p file r))))))))))
         ('files-default
          ;; File completion on default branch: /github:OWNER/REPO/[subdir/]
+         ;; Uses lightweight Contents API (single call) instead of
+         ;; recursive tree fetch for fast initial display.
          (let* ((owner (plist-get partial :owner))
                 (repo (plist-get partial :repo))
                 (branch (while-no-input
@@ -715,28 +757,22 @@ instead of blocking Emacs."
                     (subpath (if repo-end
                                 (substring directory (match-end 0))
                               ""))
-                    (canonical (format "/github:%s/%s@%s:/%s"
-                                      owner repo branch subpath))
-                    (parsed (remoto--parse-path canonical)))
-               (when parsed
-                 (remoto--ensure-tree parsed)
-                 (let* ((children (remoto--tree-children parsed))
-                        (names (mapcar (lambda (child)
-                                         (if (equal "tree" (alist-get 'type (cdr child)))
-                                             (concat (car child) "/")
-                                           (car child)))
-                                       children))
-                        (filtered (seq-filter (lambda (name)
-                                               (string-prefix-p file name))
-                                             names))
-                        (commits (remoto--fetch-file-commits
-                                  owner repo branch subpath filtered)))
-                   (mapcar (lambda (name)
-                             (let ((msg (alist-get name commits nil nil #'equal)))
-                               (if msg
-                                   (propertize name 'remoto-file-commit msg)
-                                 name)))
-                           filtered)))))))
+                    (children (while-no-input
+                                (remoto--fetch-dir-children-light
+                                 owner repo branch subpath)))
+                    (names (when (listp children)
+                             (mapcar (lambda (child)
+                                       (if (equal "tree" (alist-get 'type (cdr child)))
+                                           (concat (car child) "/")
+                                         (car child)))
+                                     children)))
+                    (filtered (when names
+                                (if (string-empty-p file)
+                                    names
+                                  (seq-filter (lambda (name)
+                                               (string-search file name))
+                                             names)))))
+               filtered))))
         ('issues
          ;; Issue/PR completion at /github:OWNER/REPO#
          (let* ((owner (plist-get partial :owner))
@@ -1510,7 +1546,7 @@ Cached per `remoto-search-cache-ttl'. Capped at 20 API calls."
                   (push (cons child msg) result))))
             (puthash key (cons now result) remoto--file-commits-cache)
             result)
-        (user-error nil)))))
+        (error nil)))))
 
 (defun remoto--fetch-user-orgs (_user)
   "Fetch organization memberships for the authenticated user.
@@ -1587,7 +1623,7 @@ Cancels any previously scheduled pre-fetch."
     (cancel-timer remoto--prefetch-timer))
   (setq remoto--prefetch-timer
         (run-with-idle-timer
-         0.05 nil
+         0.001 nil
          (lambda ()
            (setq remoto--prefetch-timer nil)
            ;; Wrap in while-no-input so typing interrupts the
@@ -1697,7 +1733,10 @@ Returns a list of owner/repo strings, or nil."
                                      (url-hexify-string
                                       (remoto--search-query query))))
                    (items (alist-get 'items (remoto--api endpoint)))
-                   (results (mapcar (lambda (item) (alist-get 'full_name item))
+                   (results (mapcar (lambda (item)
+                                     (propertize (alist-get 'full_name item)
+                                                 'remoto-repo-desc
+                                                 (or (alist-get 'description item) "")))
                                     items)))
               (remoto--search-cache-put query results))
           (user-error nil))))))
@@ -1737,18 +1776,186 @@ protocol."
 (defvar remoto--browse-history nil
   "Minibuffer history for `remoto-browse'.")
 
+(defun remoto--browse-parse-input (string)
+  "Parse STRING from `remoto-browse' into (MODE OWNER REPO QUERY).
+MODE is one of `search', `branches', `issues'.
+OWNER+REPO are non-nil for @ and # modes.
+QUERY is the text after the delimiter."
+  (cond
+   ;; owner/repo#query - issues mode
+   ((string-match (rx bos (group (+ (not (any "/@#"))))
+                      "/" (group (+ (not (any "/@#"))))
+                      "#" (group (* anything)) eos)
+                  string)
+    (list 'issues (match-string 1 string)
+          (match-string 2 string) (match-string 3 string)))
+   ;; owner/repo@query - branches mode
+   ((string-match (rx bos (group (+ (not (any "/@#"))))
+                      "/" (group (+ (not (any "/@#"))))
+                      "@" (group (* anything)) eos)
+                  string)
+    (list 'branches (match-string 1 string)
+          (match-string 2 string) (match-string 3 string)))
+   ;; owner/repo/[subpath] - files mode
+   ((string-match (rx bos (group (+ (not (any "/@#"))))
+                      "/" (group (+ (not (any "/@#"))))
+                      "/" (group (* anything)) eos)
+                  string)
+    (list 'files (match-string 1 string)
+          (match-string 2 string) (match-string 3 string)))
+   ;; plain search
+   (t (list 'search nil nil string))))
+
+(defun remoto--browse-completions (string)
+  "Return completion candidates for STRING in `remoto-browse'.
+Handles search, branch, and issue modes."
+  (pcase-let ((`(,mode ,owner ,repo ,query) (remoto--browse-parse-input string)))
+    (pcase mode
+      ('issues
+       (let* ((prefix (format "%s/%s#" owner repo))
+              (issues
+               (cond
+                ((string-empty-p query)
+                 (while-no-input (remoto--fetch-issues owner repo)))
+                ((string-match-p (rx bos (+ digit) eos) query)
+                 (let* ((cached (while-no-input
+                                  (remoto--fetch-issues owner repo)))
+                        (direct (while-no-input
+                                  (remoto--fetch-issue owner repo query)))
+                        (results (if (listp cached) cached nil)))
+                   (if direct
+                       (cl-remove-duplicates
+                        (cons direct results)
+                        :key (lambda (i) (alist-get 'number i)))
+                     results)))
+                (t (while-no-input
+                     (remoto--search-issues owner repo query))))))
+         (when (listp issues)
+           (let ((candidates
+                  (mapcar (lambda (i)
+                            (let* ((num (number-to-string (alist-get 'number i)))
+                                   (is-pr (not (null (alist-get 'pull_request i))))
+                                   (title (or (alist-get 'title i) ""))
+                                   (state (or (alist-get 'state i) "")))
+                              (propertize (concat prefix num)
+                                          'remoto-topic-pr is-pr
+                                          'remoto-topic-title title
+                                          'remoto-topic-state state)))
+                          issues)))
+             (sort candidates
+                   (lambda (a b)
+                     (let ((a-pr (get-text-property 0 'remoto-topic-pr a))
+                           (b-pr (get-text-property 0 'remoto-topic-pr b)))
+                       (cond
+                        ((and a-pr (not b-pr)) t)
+                        ((and (not a-pr) b-pr) nil)
+                        (t (> (string-to-number (replace-regexp-in-string ".*#" "" a))
+                              (string-to-number (replace-regexp-in-string ".*#" "" b))))))))))))
+      ('branches
+       (let* ((prefix (format "%s/%s@" owner repo))
+              (branches (while-no-input
+                          (remoto--fetch-branches owner repo)))
+              (tags (while-no-input
+                      (remoto--fetch-tags owner repo))))
+         (when (or (listp branches) (listp tags))
+           (let ((branch-set (when (listp branches)
+                               (mapcar (lambda (b)
+                                         (propertize (concat prefix b)
+                                                     'remoto-ref-type "branch"))
+                                       branches)))
+                 (tag-set (when (listp tags)
+                            (mapcar (lambda (tg)
+                                      (propertize (concat prefix tg)
+                                                  'remoto-ref-type "tag"))
+                                    tags))))
+             (seq-filter (lambda (r)
+                           (or (string-empty-p query)
+                               (string-prefix-p query
+                                                (replace-regexp-in-string ".*@" "" r))))
+                         (append branch-set tag-set))))))
+      ('files
+       (let* ((prefix (format "%s/%s/" owner repo))
+              (branch (while-no-input
+                        (remoto--default-branch owner repo))))
+         (when (and (stringp branch) (not (equal branch t)))
+           (let* ((subpath (if (string-search "/" query)
+                               (file-name-directory query)
+                             ""))
+                  (file-part (if (string-search "/" query)
+                                 (file-name-nondirectory query)
+                               query))
+                  (children (while-no-input
+                              (remoto--fetch-dir-children-light
+                               owner repo branch subpath)))
+                  (names (when (listp children)
+                           (mapcar (lambda (child)
+                                     (let ((name (car child))
+                                           (dir? (equal "tree"
+                                                        (alist-get 'type (cdr child)))))
+                                       (concat prefix subpath
+                                               (if dir? (concat name "/") name))))
+                                   children))))
+             (if (string-empty-p file-part)
+                 names
+               (seq-filter (lambda (n) (string-search file-part n)) names))))))
+      ('search
+       (remoto--search-repos query)))))
+
+(defun remoto--browse-metadata (string)
+  "Return completion metadata alist for STRING in `remoto-browse'."
+  (pcase (car (remoto--browse-parse-input string))
+    ('issues
+     (let ((group-fn (lambda (candidate transform)
+                       (if transform candidate
+                         (if (get-text-property 0 'remoto-topic-pr candidate)
+                             "Pull Request"
+                           "Issue"))))
+           (affix-fn (lambda (candidates)
+                       (remoto--affixate
+                        (mapcar (lambda (c)
+                                  (let ((title (or (get-text-property 0 'remoto-topic-title c) ""))
+                                        (state (or (get-text-property 0 'remoto-topic-state c) ""))
+                                        (is-pr (get-text-property 0 'remoto-topic-pr c)))
+                                    (list c
+                                          (if is-pr "PR " "   ")
+                                          (format "%s [%s]" title state))))
+                                candidates)))))
+       `(metadata (category . remoto-browse)
+                  (group-function . ,group-fn)
+                  (affixation-function . ,affix-fn))))
+    ('branches
+     (let ((group-fn (lambda (candidate transform)
+                       (if transform candidate
+                         (if (equal "tag" (get-text-property 0 'remoto-ref-type candidate))
+                             "Tag"
+                           "Branch")))))
+       `(metadata (category . remoto-browse)
+                  (group-function . ,group-fn))))
+    ('files
+     '(metadata (category . remoto-browse)))
+    ('search
+     (let ((affix-fn (lambda (candidates)
+                       (remoto--affixate
+                        (mapcar (lambda (c)
+                                  (let ((desc (or (get-text-property 0 'remoto-repo-desc c) "")))
+                                    (list c "" desc)))
+                                candidates)))))
+       `(metadata (category . remoto-browse)
+                  (affixation-function . ,affix-fn))))))
+
 (defun remoto--repo-completion-table (string pred action)
-  "Programmed completion table for GitHub repos and branches.
+  "Programmed completion table for GitHub repos, branches, and issues.
 STRING is the current minibuffer input, PRED a filter predicate,
-ACTION the completion action dispatched by `completing-read'."
+ACTION the completion action dispatched by `completing-read'.
+Detects @ and # delimiters to switch between modes."
   (if (eq action 'metadata)
-      '(metadata (category . remoto-repo))
-    (complete-with-action action (remoto--search-repos string) string pred)))
+      (remoto--browse-metadata string)
+    (complete-with-action action (remoto--browse-completions string) string pred)))
 
 (defun remoto--read-repo ()
   "Read a GitHub repo from the minibuffer with search completion.
 Type 3+ characters to trigger GitHub search.  Tab completes.
-Append @ to complete branch names (e.g. owner/repo@<Tab>).
+Append @ to complete branches/tags, # to browse issues/PRs.
 URLs and owner/repo shorthand can be typed directly."
   (completing-read "GitHub repo: "
                    #'remoto--repo-completion-table
@@ -1759,16 +1966,55 @@ URLs and owner/repo shorthand can be typed directly."
 (defun remoto-browse (input)
   "Browse a GitHub repository without cloning.
 INPUT can be any GitHub URL, git remote URL, or owner/repo shorthand.
+Supports owner/repo#NUM to view issues/PRs and owner/repo@ref for
+specific branches/tags.
 With interactive use, provides search completion - type 3+ characters
 to search GitHub repositories."
   (interactive (list (remoto--read-repo)))
-  (let* ((parsed (remoto--parse-input input))
-         (resolved (remoto--resolve-ref parsed))
-         (canonical (remoto--canonical-path resolved)))
-    (if (equal "tree"
-               (alist-get 'type (remoto--tree-entry resolved)))
-        (dired canonical)
-      (find-file canonical))))
+  (cond
+   ;; Issue/PR mode: owner/repo#NUM
+   ((string-match (rx bos (group (+ (not (any "/@#"))))
+                      "/" (group (+ (not (any "/@#"))))
+                      "#" (group (+ digit)) eos)
+                  input)
+    (let ((owner (match-string 1 input))
+          (repo (match-string 2 input))
+          (number (match-string 3 input)))
+      (remoto--require-topic)
+      (remoto-topic-display number (format "/github:%s/%s" owner repo))))
+   ;; Files mode: owner/repo/[subpath]
+   ((string-match (rx bos (group (+ (not (any "/@#"))))
+                      "/" (group (+ (not (any "/@#"))))
+                      "/" (group (* anything)) eos)
+                  input)
+    (let* ((owner (match-string 1 input))
+           (repo (match-string 2 input))
+           (subpath (match-string 3 input))
+           (canonical (remoto--maybe-rewrite
+                       (format "/github:%s/%s/%s" owner repo subpath))))
+      (if (and (remoto--parse-path canonical)
+               (equal "tree"
+                      (alist-get 'type
+                                 (remoto--tree-entry
+                                  (remoto--parse-path canonical)))))
+          (dired canonical)
+        (find-file canonical))))
+   ;; Branch mode or plain repo
+   (t
+    (let* ((clean (if (string-match (rx bos (group (+ (not (any "/@#")))
+                                                   "/" (+ (not (any "/@#"))))
+                                        "@" (group (+ nonl)) eos)
+                                    input)
+                      (format "%s@%s" (match-string 1 input)
+                              (match-string 2 input))
+                    input))
+           (parsed (remoto--parse-input clean))
+           (resolved (remoto--resolve-ref parsed))
+           (canonical (remoto--canonical-path resolved)))
+      (if (equal "tree"
+                 (alist-get 'type (remoto--tree-entry resolved)))
+          (dired canonical)
+        (find-file canonical))))))
 
 ;;;; GitHub input detection
 
@@ -2083,8 +2329,15 @@ Args: ORIG, STRING, PRED, ACTION."
 (declare-function remoto-topic-display "remoto-topic" (number repo-path))
 
 (defun remoto--require-topic ()
-  "Load remoto-topic if not already loaded."
-  (require 'remoto-topic nil t))
+  "Load remoto-topic if not already loaded.
+Adds the package directory to `load-path' if needed."
+  (unless (featurep 'remoto-topic)
+    (when-let* ((dir (file-name-directory
+                      (or load-file-name
+                          (locate-library "remoto")
+                          buffer-file-name))))
+      (add-to-list 'load-path dir))
+    (require 'remoto-topic)))
 
 ;;;; Unload
 
@@ -2104,6 +2357,7 @@ Args: ORIG, STRING, PRED, ACTION."
   (clrhash remoto--tags-cache)
   (clrhash remoto--issues-cache)
   (clrhash remoto--file-commits-cache)
+  (clrhash remoto--dir-contents-cache)
   nil)
 
 (provide 'remoto)

--- a/remoto.el
+++ b/remoto.el
@@ -1868,6 +1868,19 @@ Handles candidates with prefix prepended by completion framework."
           (get-text-property (1- len) prop candidate)
           (get-text-property 0 prop candidate)))))
 
+(defun remoto--align-affixations (items)
+  "Align ITEMS for affixation display.
+ITEMS is a list of (candidate prefix suffix). Pads each candidate
+with spaces so suffixes start at the same column."
+  (let ((max-len (apply #'max 0 (mapcar (lambda (x) (length (car x))) items))))
+    (mapcar (lambda (x)
+              (let* ((c (nth 0 x))
+                     (prefix (nth 1 x))
+                     (suffix (nth 2 x))
+                     (pad (make-string (+ 2 (- max-len (length c))) ?\s)))
+                (list c prefix (concat pad suffix))))
+            items)))
+
 (defun remoto--completion-metadata (directory)
   "Return completion metadata alist for DIRECTORY, or nil.
 Provides group-function and affixation-function for @ and # modes."
@@ -1881,14 +1894,15 @@ Provides group-function and affixation-function for @ and # modes."
                             "Pull Request"
                           "Issue"))))
           (affix-fn (lambda (candidates)
-                      (mapcar (lambda (c)
-                                (let ((title (or (remoto--get-prop c 'remoto-issue-title) ""))
-                                      (state (or (remoto--get-prop c 'remoto-issue-state) ""))
-                                      (is-pr (remoto--get-prop c 'remoto-issue-pr)))
-                                  (list c
-                                        (if is-pr "PR " "   ")
-                                        (format " %s [%s]" title state))))
-                              candidates))))
+                      (remoto--align-affixations
+                       (mapcar (lambda (c)
+                                 (let ((title (or (remoto--get-prop c 'remoto-issue-title) ""))
+                                       (state (or (remoto--get-prop c 'remoto-issue-state) ""))
+                                       (is-pr (remoto--get-prop c 'remoto-issue-pr)))
+                                   (list c
+                                         (if is-pr "PR " "   ")
+                                         (format "%s [%s]" title state))))
+                               candidates)))))
       `((group-function . ,group-fn)
         (affixation-function . ,affix-fn))))
    ;; Branches/tags mode: /github:OWNER/REPO@
@@ -1903,26 +1917,25 @@ Provides group-function and affixation-function for @ and # modes."
    ;; Owner mode: /github:OWNER/ - repo descriptions
    ((string-match (rx "/github:" (+ (not (any "/:@#"))) "/" eos) directory)
     (let ((affix-fn (lambda (candidates)
-                      (mapcar (lambda (c)
-                                (let ((desc (or (remoto--get-prop c 'remoto-repo-desc) "")))
-                                  (list c "" (if (string-empty-p desc) ""
-                                               (concat "  " desc)))))
-                              candidates))))
+                      (remoto--align-affixations
+                       (mapcar (lambda (c)
+                                 (let ((desc (or (remoto--get-prop c 'remoto-repo-desc) "")))
+                                   (list c "" desc)))
+                               candidates)))))
       `((affixation-function . ,affix-fn))))
    ;; Root mode: /github: - user/org type
    ((equal directory "/github:")
     (let ((affix-fn (lambda (candidates)
-                      (mapcar (lambda (c)
-                                (let* ((acct-type (or (remoto--get-prop c 'remoto-acct-type) ""))
-                                       (desc (or (remoto--get-prop c 'remoto-acct-desc) ""))
-                                       (suffix (cond
-                                                ((not (string-empty-p desc))
-                                                 (format "  %s  %s" acct-type desc))
-                                                ((not (string-empty-p acct-type))
-                                                 (concat "  " acct-type))
-                                                (t ""))))
-                                  (list c "" suffix)))
-                              candidates))))
+                      (remoto--align-affixations
+                       (mapcar (lambda (c)
+                                 (let* ((acct-type (or (remoto--get-prop c 'remoto-acct-type) ""))
+                                        (desc (or (remoto--get-prop c 'remoto-acct-desc) ""))
+                                        (suffix (cond
+                                                 ((not (string-empty-p desc))
+                                                  (format "%s  %s" acct-type desc))
+                                                 (t acct-type))))
+                                   (list c "" suffix)))
+                               candidates)))))
       `((affixation-function . ,affix-fn))))))
 
 (defun remoto--read-file-name-internal-a (orig string pred action)

--- a/remoto.el
+++ b/remoto.el
@@ -771,9 +771,9 @@ instead of blocking Emacs."
                                       (title (or (alist-get 'title i) ""))
                                       (state (or (alist-get 'state i) "")))
                                  (propertize num
-                                             'remoto-issue-pr is-pr
-                                             'remoto-issue-title title
-                                             'remoto-issue-state state)))
+                                             'remoto-topic-pr is-pr
+                                             'remoto-topic-title title
+                                             'remoto-topic-state state)))
                              issues))
                     (filtered
                      (if (or (string-empty-p file)
@@ -783,8 +783,8 @@ instead of blocking Emacs."
                ;; Sort: PRs first, then issues; within each group by number descending
                (sort filtered
                      (lambda (a b)
-                       (let ((a-pr (get-text-property 0 'remoto-issue-pr a))
-                             (b-pr (get-text-property 0 'remoto-issue-pr b)))
+                       (let ((a-pr (get-text-property 0 'remoto-topic-pr a))
+                             (b-pr (get-text-property 0 'remoto-topic-pr b)))
                          (cond
                           ((and a-pr (not b-pr)) t)
                           ((and (not a-pr) b-pr) nil)
@@ -1884,8 +1884,8 @@ Call ORIG-FN with FILENAME and ARGS after any rewrite."
                         (group "#") (group (+ digit)) eos)
                     filename)
       (progn
-        (remoto--require-issue)
-        (remoto-issue-display
+        (remoto--require-topic)
+        (remoto-topic-display
          (match-string 2 filename)
          (substring filename 0 (match-beginning 1))))
     (apply orig-fn (remoto--maybe-rewrite filename) args)))
@@ -1969,15 +1969,15 @@ Provides group-function and affixation-function for @ and # modes."
                   directory)
     (let ((group-fn (lambda (candidate transform)
                       (if transform candidate
-                        (if (remoto--get-prop candidate 'remoto-issue-pr)
+                        (if (remoto--get-prop candidate 'remoto-topic-pr)
                             "Pull Request"
                           "Issue"))))
           (affix-fn (lambda (candidates)
                       (remoto--affixate
                        (mapcar (lambda (c)
-                                 (let ((title (or (remoto--get-prop c 'remoto-issue-title) ""))
-                                       (state (or (remoto--get-prop c 'remoto-issue-state) ""))
-                                       (is-pr (remoto--get-prop c 'remoto-issue-pr)))
+                                 (let ((title (or (remoto--get-prop c 'remoto-topic-title) ""))
+                                       (state (or (remoto--get-prop c 'remoto-topic-state) ""))
+                                       (is-pr (remoto--get-prop c 'remoto-topic-pr)))
                                    (list c
                                          (if is-pr "PR " "   ")
                                          (format "%s [%s]" title state))))
@@ -2078,13 +2078,13 @@ Args: ORIG, STRING, PRED, ACTION."
 (advice-add 'read-file-name-internal :around
             #'remoto--read-file-name-internal-a)
 
-;;;; Issue display (see remoto-issue.el for full implementation)
+;;;; Issue display (see remoto-topic.el for full implementation)
 
-(declare-function remoto-issue-display "remoto-issue" (number repo-path))
+(declare-function remoto-topic-display "remoto-topic" (number repo-path))
 
-(defun remoto--require-issue ()
-  "Load remoto-issue if not already loaded."
-  (require 'remoto-issue nil t))
+(defun remoto--require-topic ()
+  "Load remoto-topic if not already loaded."
+  (require 'remoto-topic nil t))
 
 ;;;; Unload
 

--- a/remoto.el
+++ b/remoto.el
@@ -426,8 +426,8 @@ Pass remaining ARGS to the resolved handler."
 
 (defun remoto--handle-file-exists-p (filename)
   "Return t if FILENAME exists or is openable.
-Returns nil for paths that are mid-completion (no selection made yet),
-which triggers Emacs's `confirm-nonexistent-file-or-buffer' on RET."
+Returns nil for mid-completion paths (no selection made yet),
+triggering variable `confirm-nonexistent-file-or-buffer' on RET."
   (cond
    ;; /github: and /github:owner/ - directory-like, exist for navigation
    ((string-match (rx bos "/github:" (? "/") eos) filename) t)

--- a/remoto.el
+++ b/remoto.el
@@ -1723,9 +1723,9 @@ to search GitHub repositories."
 Returns a `remoto-path' struct or nil."
   (cond
    ((string-match (rx bos "/github:"
-                      (group (+ (not (any "/:@"))))
+                      (group (+ (not (any "/:@#"))))
                       "/"
-                      (group (+ (not (any "/:@"))))
+                      (group (+ (not (any "/:@#"))))
                       (? "@" (group (+ (not (any "/:")))))
                       eos)
                   input)
@@ -1736,9 +1736,9 @@ Returns a `remoto-path' struct or nil."
      :path "/"))
    ;; Also handle with trailing /
    ((string-match (rx bos "/github:"
-                      (group (+ (not (any "/:@"))))
+                      (group (+ (not (any "/:@#"))))
                       "/"
-                      (group (+ (not (any "/:@"))))
+                      (group (+ (not (any "/:@#"))))
                       (? "@" (group (+ (not (any "/:")))))
                       "/" eos)
                   input)
@@ -1815,14 +1815,16 @@ Call ORIG-FN with DIR-OR-LIST and ARGS after any rewrite."
   "Rewrite GitHub URLs to canonical remoto paths for `find-file'.
 Intercepts #NUM patterns to display issues instead of file operations.
 Call ORIG-FN with FILENAME and ARGS after any rewrite."
-  (let ((rewritten (remoto--maybe-rewrite filename)))
-    (if (string-match (rx "#" (group (+ digit)) eos) rewritten)
-        (progn
-          (remoto--require-issue)
-          (remoto-issue-display
-           (match-string 1 rewritten)
-           (substring rewritten 0 (match-beginning 0))))
-      (apply orig-fn rewritten args))))
+  ;; Check for #NUM BEFORE rewrite (rewrite would mangle the # delimiter)
+  (if (string-match (rx "/github:" (+ (not (any "/@#"))) "/" (+ (not (any "/@#")))
+                        (group "#") (group (+ digit)) eos)
+                    filename)
+      (progn
+        (remoto--require-issue)
+        (remoto-issue-display
+         (match-string 2 filename)
+         (substring filename 0 (match-beginning 1))))
+    (apply orig-fn (remoto--maybe-rewrite filename) args)))
 
 (unless (advice-member-p #'remoto--dired-around-a 'dired)
   (advice-add 'dired :around #'remoto--dired-around-a))

--- a/remoto.el
+++ b/remoto.el
@@ -46,6 +46,14 @@
   "Regexp matching canonical remoto paths.
 Groups: 1=owner, 2=repo, 3=ref (maybe nil), 4=path.")
 
+(defconst remoto--repo-delimiters
+  '((?/ . files-default)
+    (?@ . branches)
+    (?# . issues))
+  "Alist mapping delimiter characters after OWNER/REPO to completion levels.
+`/' means browse files on default branch, `@' means pick a branch/tag,
+`#' means browse issues/PRs.")
+
 (cl-defstruct (remoto-path (:constructor remoto-path-create)
                            (:copier nil))
   "Parsed components of a remoto path."
@@ -417,22 +425,53 @@ Pass remaining ARGS to the resolved handler."
 ;;;; Read operations
 
 (defun remoto--handle-file-exists-p (filename)
-  "Return t if FILENAME exists in the remote repo.
-Also returns t for partial paths used during completion,
-including owner/repo paths that haven't added @ yet."
+  "Return t if FILENAME exists or is openable.
+Returns nil for paths that are mid-completion (no selection made yet),
+which triggers Emacs's `confirm-nonexistent-file-or-buffer' on RET."
   (cond
+   ;; /github: and /github:owner/ - directory-like, exist for navigation
    ((string-match (rx bos "/github:" (? "/") eos) filename) t)
-   ((remoto--parse-partial-github-path
-     (remoto--handle-file-name-as-directory filename))
-    t)
-   ;; /github:owner/repo (no @) - valid during completion
    ((string-match (rx bos "/github:"
-                      (+ (not (any "/:@")))
+                      (+ (not (any "/:@#")))
+                      "/" eos)
+                  filename) t)
+   ;; /github:owner/repo/ - openable as dired on default branch
+   ((string-match (rx bos "/github:"
+                      (+ (not (any "/:@#")))
                       "/"
-                      (+ (not (any "/:@")))
-                      (? "/") eos)
+                      (+ (not (any "/:@#")))
+                      "/")
+                  filename) t)
+   ;; /github:owner/repo#NUM - specific issue ref, openable
+   ((string-match (rx bos "/github:"
+                      (+ (not (any "/:@#")))
+                      "/"
+                      (+ (not (any "/:@#")))
+                      "#"
+                      (+ digit) eos)
+                  filename) t)
+   ;; /github:owner/repo (bare) - NOT openable, still needs delimiter
+   ((string-match (rx bos "/github:"
+                      (+ (not (any "/:@#")))
+                      "/"
+                      (+ (not (any "/:@#")))
+                      eos)
                   filename)
-    t)
+    nil)
+   ;; /github:owner/repo# or /github:owner/repo@ - delimiter without selection
+   ((string-match (rx bos "/github:"
+                      (+ (not (any "/:@#")))
+                      "/"
+                      (+ (not (any "/:@#")))
+                      (any "@#") eos)
+                  filename)
+    nil)
+   ;; /github:owner# or /github:owner@ - no repo, invalid
+   ((and (string-prefix-p "/github:" filename)
+         (not (remoto--parse-path filename))
+         (string-match (rx (any "@#") eos) filename))
+    nil)
+   ;; Full canonical path - check tree
    (t
     (when-let* ((parsed (remoto--parse-path filename)))
       (and (remoto--tree-entry parsed) t)))))
@@ -542,45 +581,88 @@ Pass FULL, MATCH, NOSORT, and ID-FORMAT through unchanged."
 (defun remoto--parse-partial-github-path (directory)
   "Parse a partial /github: DIRECTORY for pre-repo completion.
 Returns a plist with :level plus context keys, or nil.
-:level is `root' for /github:, `owner' for /github:OWNER/,
-or `repo' for /github:OWNER/REPO@."
-  (cond
-   ((string-match (rx bos "/github:" eos) directory)
-    (list :level 'root :owner nil))
-   ((string-match (rx bos "/github:"
-                      (group (+ (not (any "/:@"))))
-                      "/"
-                      (group (+ (not (any "/:@"))))
-                      "@" (? "/") eos)
-                  directory)
-    (list :level 'repo
-          :owner (match-string 1 directory)
-          :repo (match-string 2 directory)))
-   ((string-match (rx bos "/github:"
-                      (group (+ (not (any "/:@"))))
-                      "/" eos)
-                  directory)
-    (list :level 'owner :owner (match-string 1 directory)))))
+Levels: `root', `owner', `repo' (branches/tags), `files-default', `issues'."
+  (when (stringp directory)
+    (cond
+     ;; /github:
+     ((string-match (rx bos "/github:" eos) directory)
+      (list :level 'root :owner nil))
+     ;; /github:owner/repo# - issues level (repo must contain no /:@#)
+     ((string-match (rx bos "/github:"
+                        (group (+ (not (any "/:@#"))))
+                        "/"
+                        (group (+ (not (any "/:@#"))))
+                        "#" eos)
+                    directory)
+      (list :level 'issues
+            :owner (match-string 1 directory)
+            :repo (match-string 2 directory)))
+     ;; /github:owner/repo@ - branches/tags level
+     ((string-match (rx bos "/github:"
+                        (group (+ (not (any "/:@#"))))
+                        "/"
+                        (group (+ (not (any "/:@#"))))
+                        "@" (? "/") eos)
+                    directory)
+      (list :level 'repo
+            :owner (match-string 1 directory)
+            :repo (match-string 2 directory)))
+     ;; /github:owner/repo/ or /github:owner/repo/subdir/ - files-default
+     ((string-match (rx bos "/github:"
+                        (group (+ (not (any "/:@#"))))
+                        "/"
+                        (group (+ (not (any ":@#"))))
+                        "/" eos)
+                    directory)
+      ;; Distinguish owner/ (level=owner) from owner/repo/ (level=files-default)
+      ;; The second group must be a repo name (no slashes) or repo/subpath
+      (let ((owner (match-string 1 directory))
+            (rest (match-string 2 directory)))
+        (if (string-match-p "/" rest)
+            ;; rest contains slash: owner/repo/subdir
+            (let* ((slash-pos (string-match "/" rest))
+                   (repo (substring rest 0 slash-pos)))
+              (list :level 'files-default
+                    :owner owner
+                    :repo repo))
+          ;; rest is just repo name
+          (list :level 'files-default
+                :owner owner
+                :repo rest))))
+     ;; /github:owner/ - owner level
+     ((string-match (rx bos "/github:"
+                        (group (+ (not (any "/:@#"))))
+                        "/" eos)
+                    directory)
+      (list :level 'owner :owner (match-string 1 directory))))))
 
 (defun remoto--handle-file-name-all-completions (file directory)
   "Return completions for FILE in remote DIRECTORY.
-Handles three levels: user search at /github:, repo listing at
-/github:OWNER/, and file listing within a repo.  Network calls
-are wrapped in `while-no-input' so typing interrupts pending API
-requests instead of blocking Emacs."
+Handles multiple levels: user search at /github:, repo listing at
+/github:OWNER/, branch/tag at /github:OWNER/REPO@, files at
+/github:OWNER/REPO/, issues at /github:OWNER/REPO#, and file
+listing within a repo.  Network calls are wrapped in
+`while-no-input' so typing interrupts pending API requests
+instead of blocking Emacs."
   (if-let* ((partial (remoto--parse-partial-github-path directory)))
       (pcase (plist-get partial :level)
         ('root
-         ;; Search users/orgs matching FILE
-         (let ((result (while-no-input (remoto--search-users file))))
-           (when (listp result)
-             (let ((filtered (thread-last result
-                               (seq-filter (lambda (u) (string-prefix-p file u))))))
-               ;; Pre-fetch repos for the top match so the cache is
-               ;; warm by the time the user types "/"
-               (when-let* ((top (car filtered)))
-                 (remoto--prefetch-owner-repos top))
-               (mapcar (lambda (u) (concat u "/")) filtered)))))
+         ;; Empty query + authenticated: show user + orgs
+         ;; Non-empty: search users/orgs matching FILE
+         (if (string-empty-p file)
+             (when-let* ((user remoto--authenticated-user))
+               (let* ((orgs (remoto--fetch-user-orgs user))
+                      (all (cons user orgs)))
+                 (mapcar (lambda (u) (concat u "/")) all)))
+           (let ((result (while-no-input (remoto--search-users file))))
+             (when (listp result)
+               (let ((filtered (thread-last result
+                                 (seq-filter (lambda (u) (string-prefix-p file u))))))
+                 ;; Pre-fetch repos for the top match so the cache is
+                 ;; warm by the time the user types "/"
+                 (when-let* ((top (car filtered)))
+                   (remoto--prefetch-owner-repos top))
+                 (mapcar (lambda (u) (concat u "/")) filtered))))))
         ('owner
          ;; Repo completion at /github:OWNER/
          (let* ((owner (plist-get partial :owner))
@@ -590,20 +672,105 @@ requests instead of blocking Emacs."
                             (remoto--search-owner-repos owner file)))))
            (when (listp result) result)))
         ('repo
-         ;; Branch completion at /github:OWNER/REPO@
+         ;; Branch + tag completion at /github:OWNER/REPO@
          (if (string-suffix-p ":" file)
-             ;; Branch already selected (e.g. "main:") - exact match
+             ;; Ref already selected (e.g. "main:") - exact match
              (list file)
            (let* ((owner (plist-get partial :owner))
                   (repo (plist-get partial :repo))
-                  (result (while-no-input
-                            (remoto--fetch-branches owner repo))))
-             (when (listp result)
-               (thread-last result
-                 (seq-filter (lambda (b)
-                               (or (string-empty-p file)
-                                   (string-prefix-p file b))))
-                 (mapcar (lambda (b) (concat b ":")))))))))
+                  (branches (while-no-input
+                              (remoto--fetch-branches owner repo)))
+                  (tags (while-no-input
+                          (remoto--fetch-tags owner repo))))
+             (when (or (listp branches) (listp tags))
+               (let ((branch-set (when (listp branches)
+                                   (mapcar (lambda (b)
+                                             (propertize (concat b ":")
+                                                        'remoto-ref-type "branch"))
+                                           branches)))
+                     (tag-set (when (listp tags)
+                                (mapcar (lambda (tg)
+                                          (propertize (concat tg ":")
+                                                     'remoto-ref-type "tag"))
+                                        tags))))
+                 (thread-last (append branch-set tag-set)
+                   (seq-filter (lambda (r)
+                                 (or (string-empty-p file)
+                                     (string-prefix-p file r))))))))))
+        ('files-default
+         ;; File completion on default branch: /github:OWNER/REPO/[subdir/]
+         (let* ((owner (plist-get partial :owner))
+                (repo (plist-get partial :repo))
+                (branch (while-no-input
+                          (remoto--default-branch owner repo))))
+           (when (and (stringp branch) (not (equal branch t)))
+             ;; Extract subpath from directory after owner/repo/
+             (let* ((repo-end (string-match
+                               (rx (+ (not (any "/:@#")))
+                                   "/"
+                                   (+ (not (any "/:@#")))
+                                   "/")
+                               directory
+                               (length "/github:")))
+                    (subpath (if repo-end
+                                (substring directory (match-end 0))
+                              ""))
+                    (canonical (format "/github:%s/%s@%s:/%s"
+                                      owner repo branch subpath))
+                    (parsed (remoto--parse-path canonical)))
+               (when parsed
+                 (remoto--ensure-tree parsed)
+                 (thread-last (remoto--tree-children parsed)
+                   (mapcar (lambda (child)
+                             (if (equal "tree" (alist-get 'type (cdr child)))
+                                 (concat (car child) "/")
+                               (car child))))
+                   (seq-filter (lambda (name)
+                                 (string-prefix-p file name)))))))))
+        ('issues
+         ;; Issue/PR completion at /github:OWNER/REPO#
+         (let* ((owner (plist-get partial :owner))
+                (repo (plist-get partial :repo))
+                (issues
+                 (cond
+                  ;; Empty query: show top open issues
+                  ((string-empty-p file)
+                   (while-no-input
+                     (remoto--fetch-issues owner repo)))
+                  ;; Numeric query: direct fetch + filter cached
+                  ((string-match-p (rx bos (+ digit) eos) file)
+                   (let* ((cached (while-no-input
+                                    (remoto--fetch-issues owner repo)))
+                          (direct (while-no-input
+                                    (remoto--fetch-issue owner repo file)))
+                          (results (if (listp cached) cached nil)))
+                     (if direct
+                         (cl-remove-duplicates
+                          (cons direct results)
+                          :key (lambda (i) (alist-get 'number i)))
+                       results)))
+                  ;; Text query: search
+                  (t
+                   (while-no-input
+                     (remoto--search-issues owner repo file))))))
+           (when (listp issues)
+             (let ((candidates
+                    (mapcar (lambda (i)
+                              (let* ((num (number-to-string (alist-get 'number i)))
+                                     (is-pr (not (null (alist-get 'pull_request i))))
+                                     (title (or (alist-get 'title i) ""))
+                                     (state (or (alist-get 'state i) "")))
+                                (propertize num
+                                            'remoto-issue-pr is-pr
+                                            'remoto-issue-title title
+                                            'remoto-issue-state state)))
+                            issues)))
+               ;; Only prefix-filter for empty/numeric queries (client-side narrowing).
+               ;; Text search results are already filtered by the API.
+               (if (or (string-empty-p file)
+                       (string-match-p (rx bos (+ digit) eos) file))
+                   (seq-filter (lambda (n) (string-prefix-p file n)) candidates)
+                 candidates))))))
     ;; Full canonical path - existing behavior
     (when-let* ((parsed (remoto--parse-path directory)))
       (thread-last (remoto--tree-children parsed)
@@ -681,38 +848,59 @@ Handles partial paths for pre-repo completion."
 
 (defun remoto--handle-file-name-directory (filename)
   "Return directory part of remote FILENAME.
-Handles partial paths for pre-repo completion."
+Handles partial paths including # and files-default short forms."
   (cond
-   ;; /github: or /github:owner/ - already a directory
-   ((string-match (rx bos "/github:" (* (not (any "/:@"))) (? "/") eos)
-                  filename)
-    (if (string-suffix-p "/" filename) filename
-      ;; /github:foo -> /github:
-      (if (string-match (rx bos "/github:" eos) filename)
-          "/github:"
-        (concat (file-name-directory (substring filename 0 -1))
-                ;; edge case: /github:foo -> directory is /github:
-                ;; but file-name-directory on /github:fo would return /
-                ;; so handle manually
-                ""))))
-   ;; /github:owner/repo@branch - treat repo@ as directory
+   ;; /github:owner/repo#query - # is delimiter, directory is up to and including #
    ((and (string-prefix-p "/github:" filename)
          (not (remoto--parse-path filename))
          (string-match (rx bos "/github:"
-                           (+ (not (any "/:@")))
+                           (+ (not (any "/:@#")))
                            "/"
-                           (+ (not (any "/:@")))
+                           (+ (not (any "/:@#")))
+                           "#")
+                       filename))
+    (match-string 0 filename))
+   ;; /github:owner/repo@... - treat repo@ as directory
+   ((and (string-prefix-p "/github:" filename)
+         (not (remoto--parse-path filename))
+         (string-match (rx bos "/github:"
+                           (+ (not (any "/:@#")))
+                           "/"
+                           (+ (not (any "/:@#")))
                            "@")
                        filename))
     (match-string 0 filename))
-   ;; /github:owner/repo (no @)
+   ;; /github:owner/repo/... - files-default short form
    ((and (string-prefix-p "/github:" filename)
          (not (remoto--parse-path filename))
          (string-match (rx bos "/github:"
-                           (+ (not (any "/:@")))
+                           (+ (not (any "/:@#")))
+                           "/"
+                           (+ (not (any "/:@#")))
+                           "/")
+                       filename))
+    (if (string-suffix-p "/" filename)
+        filename
+      ;; Find the last / and return everything up to and including it
+      (let ((last-slash (string-match-p (rx "/" (+ (not "/")) eos) filename)))
+        (if last-slash
+            (substring filename 0 (1+ last-slash))
+          filename))))
+   ;; /github:owner/repo (bare, no delimiter) -> directory is /github:owner/
+   ((and (string-prefix-p "/github:" filename)
+         (not (remoto--parse-path filename))
+         (string-match (rx bos "/github:"
+                           (+ (not (any "/:@#")))
                            "/")
                        filename))
     (match-string 0 filename))
+   ;; /github: or /github:owner or /github:owner-with-specials
+   ;; Anything after /github: without a / is the owner query
+   ((and (string-prefix-p "/github:" filename)
+         (not (remoto--parse-path filename)))
+    (if (string-match (rx bos "/github:" eos) filename)
+        "/github:"
+      "/github:"))
    ;; Full canonical path
    (t
     (when-let* ((parsed (remoto--parse-path filename))
@@ -725,35 +913,74 @@ Handles partial paths for pre-repo completion."
 
 (defun remoto--handle-file-name-nondirectory (filename)
   "Return non-directory part of remote FILENAME.
-Handles partial paths for pre-repo completion."
+Handles partial paths including # and files-default short forms."
   (cond
    ;; /github: -> ""
    ((string-match (rx bos "/github:" eos) filename) "")
+   ;; /github:owner/repo#query - nondirectory is text after #
+   ((and (string-prefix-p "/github:" filename)
+         (not (remoto--parse-path filename))
+         (string-match (rx bos "/github:"
+                           (+ (not (any "/:@#")))
+                           "/"
+                           (+ (not (any "/:@#")))
+                           "#"
+                           (group (* anything)) eos)
+                       filename))
+    (match-string 1 filename))
+   ;; /github:owner/repo@ -> ""
+   ((and (string-prefix-p "/github:" filename)
+         (not (remoto--parse-path filename))
+         (string-match (rx bos "/github:"
+                           (+ (not (any "/:@#")))
+                           "/"
+                           (+ (not (any "/:@#")))
+                           "@" eos)
+                       filename))
+    "")
+   ;; /github:owner/repo@branch -> "branch"
+   ((and (string-prefix-p "/github:" filename)
+         (not (remoto--parse-path filename))
+         (string-match (rx bos "/github:"
+                           (+ (not (any "/:@#")))
+                           "/"
+                           (+ (not (any "/:@#")))
+                           "@"
+                           (group (+ (not (any "/:@"))))
+                           eos)
+                       filename))
+    (match-string 1 filename))
+   ;; /github:owner/repo/path - files-default short form
+   ((and (string-prefix-p "/github:" filename)
+         (not (remoto--parse-path filename))
+         (string-match (rx bos "/github:"
+                           (+ (not (any "/:@#")))
+                           "/"
+                           (+ (not (any "/:@#")))
+                           "/")
+                       filename))
+    ;; After repo/, extract the last component without re-entering handler
+    (if (string-suffix-p "/" filename)
+        ""
+      (let ((last-slash (string-match-p (rx "/" (+ (not "/")) eos) filename)))
+        (if last-slash
+            (substring filename (1+ last-slash))
+          ""))))
    ;; /github:owner/ -> ""
    ((and (string-prefix-p "/github:" filename)
          (string-suffix-p "/" filename)
          (not (remoto--parse-path filename)))
     "")
-   ;; /github:owner -> "owner"
-   ((string-match (rx bos "/github:" (group (+ (not (any "/:@")))) eos)
-                  filename)
-    (match-string 1 filename))
-   ;; /github:owner/repo@ -> ""
-   ((and (string-prefix-p "/github:" filename)
-         (string-suffix-p "@" filename)
-         (not (remoto--parse-path filename)))
-    "")
-   ;; /github:owner/repo@branch -> "branch"
+   ;; /github:owner/repo (bare, no delimiter) -> "repo"
    ((and (string-prefix-p "/github:" filename)
          (not (remoto--parse-path filename))
-         (string-match (rx "@" (group (+ (not (any "/:@")))) eos) filename))
-    (match-string 1 filename))
-   ;; /github:owner/repo -> "repo"
-   ((and (string-prefix-p "/github:" filename)
-         (not (remoto--parse-path filename))
-         (string-match (rx bos "/github:" (+ (not (any "/:@"))) "/"
-                           (group (+ nonl)) eos)
+         (string-match (rx bos "/github:" (+ (not (any "/:@#"))) "/"
+                           (group (+ (not (any "/:@#")))) eos)
                        filename))
+    (match-string 1 filename))
+   ;; /github:query - everything after /github: is the query (owner or owner#, etc.)
+   ((and (not (remoto--parse-path filename))
+         (string-match (rx bos "/github:" (group (+ anything)) eos) filename))
     (match-string 1 filename))
    ;; Full canonical path
    (t
@@ -1151,6 +1378,76 @@ Otherwise searches by repository name."
             branches)
         (user-error nil)))))
 
+(defvar remoto--tags-cache (make-hash-table :test 'equal)
+  "Cache for repository tags.  key -> (TIMESTAMP . TAGS-LIST).")
+
+(defun remoto--fetch-tags (owner repo)
+  "Fetch tag names for OWNER/REPO, cached per `remoto-search-cache-ttl'."
+  (let* ((key (format "%s/%s" owner repo))
+         (entry (gethash key remoto--tags-cache))
+         (now (float-time)))
+    (if (and entry
+             (or (zerop remoto-search-cache-ttl)
+                 (< (- now (car entry)) remoto-search-cache-ttl)))
+        (cdr entry)
+      (condition-case nil
+          (let* ((endpoint (format "repos/%s/%s/tags?per_page=100" owner repo))
+                 (data (remoto--api endpoint))
+                 (tags (mapcar (lambda (item) (alist-get 'name item)) data)))
+            (puthash key (cons now tags) remoto--tags-cache)
+            tags)
+        (user-error nil)))))
+
+(defvar remoto--issues-cache (make-hash-table :test 'equal)
+  "Cache for issue listings.  key -> (TIMESTAMP . ISSUES-ALIST).")
+
+(defun remoto--fetch-issues (owner repo)
+  "Fetch open issues+PRs for OWNER/REPO, cached."
+  (let* ((key (format "%s/%s" owner repo))
+         (entry (gethash key remoto--issues-cache))
+         (now (float-time)))
+    (if (and entry
+             (or (zerop remoto-search-cache-ttl)
+                 (< (- now (car entry)) remoto-search-cache-ttl)))
+        (cdr entry)
+      (condition-case nil
+          (let* ((endpoint (format "repos/%s/%s/issues?state=open&sort=updated&per_page=30"
+                                   owner repo))
+                 (data (remoto--api endpoint)))
+            (puthash key (cons now data) remoto--issues-cache)
+            data)
+        (user-error nil)))))
+
+(defun remoto--search-issues (owner repo query)
+  "Search issues+PRs in OWNER/REPO matching QUERY."
+  (condition-case nil
+      (let* ((endpoint (format "search/issues?q=%s+repo:%s/%s&per_page=30"
+                               (url-hexify-string query) owner repo))
+             (data (remoto--api endpoint)))
+        (alist-get 'items data))
+    (user-error nil)))
+
+(defun remoto--fetch-issue (owner repo number)
+  "Fetch single issue NUMBER from OWNER/REPO."
+  (condition-case nil
+      (remoto--api (format "repos/%s/%s/issues/%s" owner repo number))
+    (user-error nil)))
+
+(defun remoto--fetch-issue-comments (owner repo number)
+  "Fetch comments for issue NUMBER from OWNER/REPO.
+Returns list of comment alists, or nil on error."
+  (condition-case nil
+      (remoto--api (format "repos/%s/%s/issues/%s/comments" owner repo number))
+    (user-error nil)))
+
+(defun remoto--fetch-user-orgs (user)
+  "Fetch organization memberships for USER."
+  (condition-case nil
+      (let* ((endpoint (format "users/%s/orgs?per_page=100" user))
+             (data (remoto--api endpoint)))
+        (mapcar (lambda (item) (alist-get 'login item)) data))
+    (user-error nil)))
+
 (defun remoto--search-users (prefix)
   "Search GitHub users/orgs matching PREFIX, cached with TTL.
 Returns a list of login strings. Requires at least 2 characters.
@@ -1431,6 +1728,26 @@ Otherwise return INPUT unchanged."
   (cond
    ;; Already a full canonical path
    ((remoto--parse-path input) input)
+   ;; Files-default short form: /github:owner/repo/ or /github:owner/repo/path
+   ((and (string-prefix-p "/github:" input)
+         (not (remoto--parse-path input))
+         (string-match (rx bos "/github:"
+                           (group (+ (not (any "/:@#"))))
+                           "/"
+                           (group (+ (not (any "/:@#"))))
+                           "/" (group (* anything)) eos)
+                       input))
+    (let* ((owner (match-string 1 input))
+           (repo (match-string 2 input))
+           (subpath (match-string 3 input))
+           (repo-id (format "%s/%s" owner repo))
+           (branch (or (gethash repo-id remoto--default-branch-cache)
+                       (let ((b (remoto--default-branch owner repo)))
+                         (when b (puthash repo-id b remoto--default-branch-cache))
+                         b))))
+      (if branch
+          (format "/github:%s/%s@%s:/%s" owner repo branch subpath)
+        input)))
    ;; Partial canonical path: /github:owner/repo or /github:owner/repo@ref
    ((and (string-prefix-p "/github:" input)
          (remoto--parse-partial-canonical input))
@@ -1469,8 +1786,14 @@ Call ORIG-FN with DIR-OR-LIST and ARGS after any rewrite."
 
 (defun remoto--find-file-around-a (orig-fn filename &rest args)
   "Rewrite GitHub URLs to canonical remoto paths for `find-file'.
+Intercepts #NUM patterns to display issues instead of file operations.
 Call ORIG-FN with FILENAME and ARGS after any rewrite."
-  (apply orig-fn (remoto--maybe-rewrite filename) args))
+  (let ((rewritten (remoto--maybe-rewrite filename)))
+    (if (string-match (rx "#" (group (+ digit)) eos) rewritten)
+        (remoto-issue-display
+         (match-string 1 rewritten)
+         (substring rewritten 0 (match-beginning 0)))
+      (apply orig-fn rewritten args))))
 
 (unless (advice-member-p #'remoto--dired-around-a 'dired)
   (advice-add 'dired :around #'remoto--dired-around-a))
@@ -1500,19 +1823,61 @@ repo listings."
   (push (cons remoto--handler-regexp #'remoto-file-name-handler)
         file-name-handler-alist))
 
+(defun remoto--completion-metadata (directory)
+  "Return completion metadata alist for DIRECTORY, or nil.
+Provides group-function and affixation-function for @ and # modes."
+  (cond
+   ;; Issues mode: /github:OWNER/REPO#
+   ((string-match (rx (+ (not (any "/:@#"))) "/" (+ (not (any "/:@#"))) "#" eos)
+                  directory)
+    (let ((group-fn (lambda (candidate transform)
+                      (if transform candidate
+                        (if (get-text-property 0 'remoto-issue-pr candidate)
+                            "Pull Request"
+                          "Issue"))))
+          (affix-fn (lambda (candidates)
+                      (mapcar (lambda (c)
+                                (let ((title (or (get-text-property 0 'remoto-issue-title c) ""))
+                                      (state (or (get-text-property 0 'remoto-issue-state c) ""))
+                                      (is-pr (get-text-property 0 'remoto-issue-pr c)))
+                                  (list c
+                                        (if is-pr "PR " "   ")
+                                        (format " %s [%s]" title state))))
+                              candidates))))
+      `((group-function . ,group-fn)
+        (affixation-function . ,affix-fn))))
+   ;; Branches/tags mode: /github:OWNER/REPO@
+   ((string-match (rx (+ (not (any "/:@#"))) "/" (+ (not (any "/:@#"))) "@" eos)
+                  directory)
+    (let ((group-fn (lambda (candidate transform)
+                      (if transform candidate
+                        (if (equal "tag" (get-text-property 0 'remoto-ref-type candidate))
+                            "Tag"
+                          "Branch")))))
+      `((group-function . ,group-fn))))))
+
 (defun remoto--read-file-name-internal-a (orig string pred action)
   "Fix completion for /github: paths inside `read-file-name'.
 Re-attaches the raw prefix that `substitute-in-file-name' strips,
 so completion frameworks (Vertico, etc.) can match candidates
 against the actual minibuffer content.
+Injects completion metadata (grouping, affixation) for @ and # modes.
 Args: ORIG, STRING, PRED, ACTION."
   (let ((effective (substitute-in-file-name string)))
     (cond
      ;; Non-github path - pass through.
      ((not (string-prefix-p "/github:" effective))
       (funcall orig string pred action))
-     ;; Non-standard action (metadata, boundaries, etc.) - pass
-     ;; through with the original string so internal quoting works.
+     ;; Metadata action - inject our metadata for @ and # modes.
+     ((eq action 'metadata)
+      (let* ((dir (or (file-name-directory effective) ""))
+             (extra (remoto--completion-metadata dir))
+             (base (funcall orig string pred action))
+             (base-alist (and (consp base) (eq (car base) 'metadata) (cdr base))))
+        (if extra
+            (cons 'metadata (append extra base-alist))
+          (or base (cons 'metadata nil)))))
+     ;; Non-standard action (boundaries, etc.) - pass through.
      ((not (memq action '(nil t lambda)))
       (funcall orig string pred action))
      ;; Standard completion action - fixup prefixes.
@@ -1537,6 +1902,105 @@ Args: ORIG, STRING, PRED, ACTION."
 (advice-add 'read-file-name-internal :around
             #'remoto--read-file-name-internal-a)
 
+;;;; Issue display
+
+(defvar-local remoto-issue--number nil
+  "Issue number displayed in this buffer.")
+
+(defvar-local remoto-issue--repo-path nil
+  "Repo path (e.g. \"/github:owner/repo\") for this issue buffer.")
+
+(defvar remoto-issue-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "b" #'remoto-issue-browse)
+    (define-key map "g" #'remoto-issue-refresh)
+    map)
+  "Keymap for `remoto-issue-mode'.")
+
+(define-derived-mode remoto-issue-mode special-mode "Remoto-Issue"
+  "Major mode for viewing GitHub issues and pull requests."
+  :group 'remoto)
+
+(defun remoto-issue-browse ()
+  "Open the current issue in a web browser."
+  (interactive)
+  (when-let* ((number remoto-issue--number)
+              (path remoto-issue--repo-path)
+              (_ (string-match (rx "/github:" (group (+ nonl))) path))
+              (repo-slug (match-string 1 path)))
+    (browse-url (format "https://github.com/%s/issues/%s" repo-slug number))))
+
+(defun remoto-issue-refresh ()
+  "Re-fetch and redisplay the current issue."
+  (interactive)
+  (when (and remoto-issue--number remoto-issue--repo-path)
+    (remoto-issue-display remoto-issue--number remoto-issue--repo-path)))
+
+(defun remoto-issue--format-date (date-str)
+  "Format DATE-STR (ISO 8601) to YYYY-MM-DD."
+  (if (and date-str (string-match (rx bos (group (= 4 digit) "-" (= 2 digit) "-" (= 2 digit))) date-str))
+      (match-string 1 date-str)
+    (or date-str "")))
+
+(defun remoto-issue--render (issue comments)
+  "Render ISSUE and COMMENTS into the current buffer."
+  (let* ((number (alist-get 'number issue))
+         (title (or (alist-get 'title issue) ""))
+         (state (or (alist-get 'state issue) "unknown"))
+         (user (alist-get 'user issue))
+         (author (or (and user (alist-get 'login user)) "unknown"))
+         (labels (alist-get 'labels issue))
+         (label-names (mapcar (lambda (l) (alist-get 'name l)) labels))
+         (created (remoto-issue--format-date (alist-get 'created_at issue)))
+         (body (or (alist-get 'body issue) "")))
+    (insert (format "#%s %s" number title))
+    (insert (format "%40s" (format "[%s]" state)))
+    (insert "\n")
+    (insert (format "Author: %s" author))
+    (when label-names
+      (insert (format " | Labels: %s" (string-join label-names ", "))))
+    (insert (format " | %s" created))
+    (insert "\n\n---\n")
+    (insert body)
+    (insert "\n")
+    (when comments
+      (insert "\n---\n## Comments\n")
+      (dolist (comment comments)
+        (let* ((c-user (alist-get 'user comment))
+               (c-author (or (and c-user (alist-get 'login c-user)) "unknown"))
+               (c-date (remoto-issue--format-date (alist-get 'created_at comment)))
+               (c-body (or (alist-get 'body comment) "")))
+          (insert (format "\n### %s - %s\n" c-author c-date))
+          (insert c-body)
+          (insert "\n"))))))
+
+(defun remoto-issue-display (number repo-path)
+  "Fetch and display issue NUMBER for the repo at REPO-PATH.
+REPO-PATH is like \"/github:owner/repo\".
+Creates buffer *remoto: owner/repo#NUMBER*."
+  (unless (string-match (rx "/github:" (group (+ (not (any "/@#"))))
+                            "/" (group (+ (not (any "/@#")))))
+                        repo-path)
+    (user-error "Remoto: invalid repo path: %s" repo-path))
+  (let* ((owner (match-string 1 repo-path))
+         (repo (match-string 2 repo-path))
+         (issue (remoto--fetch-issue owner repo number)))
+    (unless issue
+      (user-error "Remoto: not found: %s/%s#%s" owner repo number))
+    (let* ((comments (remoto--fetch-issue-comments owner repo number))
+           (buf-name (format "*remoto: %s/%s#%s*" owner repo number))
+           (buf (get-buffer-create buf-name)))
+      (with-current-buffer buf
+        (let ((inhibit-read-only t))
+          (erase-buffer)
+          (remoto-issue--render issue comments))
+        (goto-char (point-min))
+        (remoto-issue-mode)
+        (setq remoto-issue--number number)
+        (setq remoto-issue--repo-path repo-path))
+      (pop-to-buffer buf)
+      buf)))
+
 ;;;; Unload
 
 (defun remoto-unload-function ()
@@ -1546,7 +2010,14 @@ Args: ORIG, STRING, PRED, ACTION."
   (advice-remove 'dired #'remoto--dired-around-a)
   (advice-remove 'find-file-noselect #'remoto--find-file-around-a)
   (advice-remove 'read-file-name-internal #'remoto--read-file-name-internal-a)
+  (clrhash remoto--tree-cache)
+  (clrhash remoto--default-branch-cache)
+  (clrhash remoto--branches-cache)
   (clrhash remoto--users-cache)
+  (clrhash remoto--content-cache)
+  (clrhash remoto--search-cache)
+  (clrhash remoto--tags-cache)
+  (clrhash remoto--issues-cache)
   nil)
 
 (provide 'remoto)

--- a/remoto.el
+++ b/remoto.el
@@ -652,7 +652,7 @@ instead of blocking Emacs."
          (if (string-empty-p file)
              (when-let* ((user remoto--authenticated-user))
                (let* ((orgs (remoto--fetch-user-orgs user))
-                      (all (cons user orgs)))
+                      (all (cons (propertize user 'remoto-acct-type "User") orgs)))
                  (mapcar (lambda (u) (concat u "/")) all)))
            (let ((result (while-no-input (remoto--search-users file))))
              (when (listp result)
@@ -1450,10 +1450,16 @@ Returns list of comment alists, or nil on error."
 
 (defun remoto--fetch-user-orgs (_user)
   "Fetch organization memberships for the authenticated user.
-Uses /user/orgs which includes private memberships."
+Uses /user/orgs which includes private memberships.
+Returns propertized login strings with type and description."
   (condition-case nil
       (let ((data (remoto--api "user/orgs?per_page=100")))
-        (mapcar (lambda (item) (alist-get 'login item)) data))
+        (mapcar (lambda (item)
+                  (propertize (alist-get 'login item)
+                              'remoto-acct-type "Organization"
+                              'remoto-acct-desc
+                              (or (alist-get 'description item) "")))
+                data))
     (user-error nil)))
 
 
@@ -1493,7 +1499,11 @@ Uses client-side narrowing when a parent query is cached."
                   (let* ((endpoint (format "search/users?q=%s&per_page=30"
                                            (url-hexify-string prefix)))
                          (items (alist-get 'items (remoto--api endpoint)))
-                         (results (mapcar (lambda (item) (alist-get 'login item))
+                         (results (mapcar (lambda (item)
+                                            (propertize
+                                             (alist-get 'login item)
+                                             'remoto-acct-type
+                                             (or (alist-get 'type item) "")))
                                           items)))
                     (puthash prefix-down (cons (float-time) results)
                              remoto--users-cache)
@@ -1842,12 +1852,20 @@ repo listings."
   (push (cons remoto--handler-regexp #'remoto-file-name-handler)
         file-name-handler-alist))
 
+;; Register completion styles for our category so filtering works
+;; like file-name completion (partial-completion understands path separators).
+(add-to-list 'completion-category-defaults
+             '(remoto (styles partial-completion basic)))
+
 (defun remoto--get-prop (candidate prop)
-  "Get text property PROP from CANDIDATE, searching from end.
+  "Get text property PROP from CANDIDATE.
+Searches from the end backwards, skipping trailing delimiters.
 Handles candidates with prefix prepended by completion framework."
   (let ((len (length candidate)))
     (when (< 0 len)
-      (or (get-text-property (1- len) prop candidate)
+      ;; Try near end (skip trailing / : characters which lack props)
+      (or (and (< 1 len) (get-text-property (- len 2) prop candidate))
+          (get-text-property (1- len) prop candidate)
           (get-text-property 0 prop candidate)))))
 
 (defun remoto--completion-metadata (directory)
@@ -1889,6 +1907,21 @@ Provides group-function and affixation-function for @ and # modes."
                                 (let ((desc (or (remoto--get-prop c 'remoto-repo-desc) "")))
                                   (list c "" (if (string-empty-p desc) ""
                                                (concat "  " desc)))))
+                              candidates))))
+      `((affixation-function . ,affix-fn))))
+   ;; Root mode: /github: - user/org type
+   ((equal directory "/github:")
+    (let ((affix-fn (lambda (candidates)
+                      (mapcar (lambda (c)
+                                (let* ((acct-type (or (remoto--get-prop c 'remoto-acct-type) ""))
+                                       (desc (or (remoto--get-prop c 'remoto-acct-desc) ""))
+                                       (suffix (cond
+                                                ((not (string-empty-p desc))
+                                                 (format "  %s  %s" acct-type desc))
+                                                ((not (string-empty-p acct-type))
+                                                 (concat "  " acct-type))
+                                                (t ""))))
+                                  (list c "" suffix)))
                               candidates))))
       `((affixation-function . ,affix-fn))))))
 

--- a/remoto.el
+++ b/remoto.el
@@ -754,23 +754,31 @@ instead of blocking Emacs."
                    (while-no-input
                      (remoto--search-issues owner repo file))))))
            (when (listp issues)
-             (let ((candidates
-                    (mapcar (lambda (i)
-                              (let* ((num (number-to-string (alist-get 'number i)))
-                                     (is-pr (not (null (alist-get 'pull_request i))))
-                                     (title (or (alist-get 'title i) ""))
-                                     (state (or (alist-get 'state i) "")))
-                                (propertize num
-                                            'remoto-issue-pr is-pr
-                                            'remoto-issue-title title
-                                            'remoto-issue-state state)))
-                            issues)))
-               ;; Only prefix-filter for empty/numeric queries (client-side narrowing).
-               ;; Text search results are already filtered by the API.
-               (if (or (string-empty-p file)
-                       (string-match-p (rx bos (+ digit) eos) file))
-                   (seq-filter (lambda (n) (string-prefix-p file n)) candidates)
-                 candidates))))))
+             (let* ((candidates
+                     (mapcar (lambda (i)
+                               (let* ((num (number-to-string (alist-get 'number i)))
+                                      (is-pr (not (null (alist-get 'pull_request i))))
+                                      (title (or (alist-get 'title i) ""))
+                                      (state (or (alist-get 'state i) "")))
+                                 (propertize num
+                                             'remoto-issue-pr is-pr
+                                             'remoto-issue-title title
+                                             'remoto-issue-state state)))
+                             issues))
+                    (filtered
+                     (if (or (string-empty-p file)
+                             (string-match-p (rx bos (+ digit) eos) file))
+                         (seq-filter (lambda (n) (string-prefix-p file n)) candidates)
+                       candidates)))
+               ;; Sort: PRs first, then issues; within each group by number descending
+               (sort filtered
+                     (lambda (a b)
+                       (let ((a-pr (get-text-property 0 'remoto-issue-pr a))
+                             (b-pr (get-text-property 0 'remoto-issue-pr b)))
+                         (cond
+                          ((and a-pr (not b-pr)) t)
+                          ((and (not a-pr) b-pr) nil)
+                          (t (> (string-to-number a) (string-to-number b))))))))))))
     ;; Full canonical path - existing behavior
     (when-let* ((parsed (remoto--parse-path directory)))
       (thread-last (remoto--tree-children parsed)
@@ -1440,13 +1448,15 @@ Returns list of comment alists, or nil on error."
       (remoto--api (format "repos/%s/%s/issues/%s/comments" owner repo number))
     (user-error nil)))
 
-(defun remoto--fetch-user-orgs (user)
-  "Fetch organization memberships for USER."
+(defun remoto--fetch-user-orgs (_user)
+  "Fetch organization memberships for the authenticated user.
+Uses /user/orgs which includes private memberships."
   (condition-case nil
-      (let* ((endpoint (format "users/%s/orgs?per_page=100" user))
-             (data (remoto--api endpoint)))
+      (let ((data (remoto--api "user/orgs?per_page=100")))
         (mapcar (lambda (item) (alist-get 'login item)) data))
     (user-error nil)))
+
+
 
 (defun remoto--search-users (prefix)
   "Search GitHub users/orgs matching PREFIX, cached with TTL.
@@ -1503,7 +1513,7 @@ Cancels any previously scheduled pre-fetch."
     (cancel-timer remoto--prefetch-timer))
   (setq remoto--prefetch-timer
         (run-with-idle-timer
-         0.25 nil
+         0.05 nil
          (lambda ()
            (setq remoto--prefetch-timer nil)
            ;; Wrap in while-no-input so typing interrupts the
@@ -1513,7 +1523,8 @@ Cancels any previously scheduled pre-fetch."
 
 (defun remoto--recent-owner-repos (owner)
   "Fetch recently-updated repos for OWNER, cached with TTL.
-Returns up to 30 repo name strings, sorted by last push."
+Returns up to 30 repo name strings (propertized with description),
+sorted by last push."
   (let* ((cache-key (format "\0repos-recent:%s" (downcase owner))))
     (pcase-let ((`(,hit ,results) (remoto--search-cache-get cache-key)))
       (if hit results
@@ -1521,7 +1532,10 @@ Returns up to 30 repo name strings, sorted by last push."
             (let* ((q (url-hexify-string (format "user:%s" owner)))
                    (endpoint (format "search/repositories?q=%s&sort=updated&per_page=30" q))
                    (items (alist-get 'items (remoto--api endpoint)))
-                   (repos (mapcar (lambda (item) (alist-get 'name item))
+                   (repos (mapcar (lambda (item)
+                                    (propertize (alist-get 'name item)
+                                                'remoto-repo-desc
+                                                (or (alist-get 'description item) "")))
                                   items)))
               (remoto--search-cache-put cache-key repos))
           (user-error nil))))))
@@ -1558,7 +1572,10 @@ Uses client-side narrowing when a parent query is cached."
                             (format "%s in:name user:%s" query owner)))
                          (endpoint (format "search/repositories?q=%s&per_page=100" q))
                          (items (alist-get 'items (remoto--api endpoint)))
-                         (repos (mapcar (lambda (item) (alist-get 'name item))
+                         (repos (mapcar (lambda (item)
+                                          (propertize (alist-get 'name item)
+                                                      'remoto-repo-desc
+                                                      (or (alist-get 'description item) "")))
                                         items)))
                     (remoto--search-cache-put cache-key repos))
                 (user-error nil)))))))))
@@ -1790,9 +1807,11 @@ Intercepts #NUM patterns to display issues instead of file operations.
 Call ORIG-FN with FILENAME and ARGS after any rewrite."
   (let ((rewritten (remoto--maybe-rewrite filename)))
     (if (string-match (rx "#" (group (+ digit)) eos) rewritten)
-        (remoto-issue-display
-         (match-string 1 rewritten)
-         (substring rewritten 0 (match-beginning 0)))
+        (progn
+          (remoto--require-issue)
+          (remoto-issue-display
+           (match-string 1 rewritten)
+           (substring rewritten 0 (match-beginning 0))))
       (apply orig-fn rewritten args))))
 
 (unless (advice-member-p #'remoto--dired-around-a 'dired)
@@ -1854,7 +1873,16 @@ Provides group-function and affixation-function for @ and # modes."
                         (if (equal "tag" (get-text-property 0 'remoto-ref-type candidate))
                             "Tag"
                           "Branch")))))
-      `((group-function . ,group-fn))))))
+      `((group-function . ,group-fn))))
+   ;; Owner mode: /github:OWNER/ - repo descriptions
+   ((string-match (rx "/github:" (+ (not (any "/:@#"))) "/" eos) directory)
+    (let ((affix-fn (lambda (candidates)
+                      (mapcar (lambda (c)
+                                (let ((desc (or (get-text-property 0 'remoto-repo-desc c) "")))
+                                  (list c "" (if (string-empty-p desc) ""
+                                               (concat "  " desc)))))
+                              candidates))))
+      `((affixation-function . ,affix-fn))))))
 
 (defun remoto--read-file-name-internal-a (orig string pred action)
   "Fix completion for /github: paths inside `read-file-name'.
@@ -1902,104 +1930,13 @@ Args: ORIG, STRING, PRED, ACTION."
 (advice-add 'read-file-name-internal :around
             #'remoto--read-file-name-internal-a)
 
-;;;; Issue display
+;;;; Issue display (see remoto-issue.el for full implementation)
 
-(defvar-local remoto-issue--number nil
-  "Issue number displayed in this buffer.")
+(declare-function remoto-issue-display "remoto-issue" (number repo-path))
 
-(defvar-local remoto-issue--repo-path nil
-  "Repo path (e.g. \"/github:owner/repo\") for this issue buffer.")
-
-(defvar remoto-issue-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map "b" #'remoto-issue-browse)
-    (define-key map "g" #'remoto-issue-refresh)
-    map)
-  "Keymap for `remoto-issue-mode'.")
-
-(define-derived-mode remoto-issue-mode special-mode "Remoto-Issue"
-  "Major mode for viewing GitHub issues and pull requests."
-  :group 'remoto)
-
-(defun remoto-issue-browse ()
-  "Open the current issue in a web browser."
-  (interactive)
-  (when-let* ((number remoto-issue--number)
-              (path remoto-issue--repo-path)
-              (_ (string-match (rx "/github:" (group (+ nonl))) path))
-              (repo-slug (match-string 1 path)))
-    (browse-url (format "https://github.com/%s/issues/%s" repo-slug number))))
-
-(defun remoto-issue-refresh ()
-  "Re-fetch and redisplay the current issue."
-  (interactive)
-  (when (and remoto-issue--number remoto-issue--repo-path)
-    (remoto-issue-display remoto-issue--number remoto-issue--repo-path)))
-
-(defun remoto-issue--format-date (date-str)
-  "Format DATE-STR (ISO 8601) to YYYY-MM-DD."
-  (if (and date-str (string-match (rx bos (group (= 4 digit) "-" (= 2 digit) "-" (= 2 digit))) date-str))
-      (match-string 1 date-str)
-    (or date-str "")))
-
-(defun remoto-issue--render (issue comments)
-  "Render ISSUE and COMMENTS into the current buffer."
-  (let* ((number (alist-get 'number issue))
-         (title (or (alist-get 'title issue) ""))
-         (state (or (alist-get 'state issue) "unknown"))
-         (user (alist-get 'user issue))
-         (author (or (and user (alist-get 'login user)) "unknown"))
-         (labels (alist-get 'labels issue))
-         (label-names (mapcar (lambda (l) (alist-get 'name l)) labels))
-         (created (remoto-issue--format-date (alist-get 'created_at issue)))
-         (body (or (alist-get 'body issue) "")))
-    (insert (format "#%s %s" number title))
-    (insert (format "%40s" (format "[%s]" state)))
-    (insert "\n")
-    (insert (format "Author: %s" author))
-    (when label-names
-      (insert (format " | Labels: %s" (string-join label-names ", "))))
-    (insert (format " | %s" created))
-    (insert "\n\n---\n")
-    (insert body)
-    (insert "\n")
-    (when comments
-      (insert "\n---\n## Comments\n")
-      (dolist (comment comments)
-        (let* ((c-user (alist-get 'user comment))
-               (c-author (or (and c-user (alist-get 'login c-user)) "unknown"))
-               (c-date (remoto-issue--format-date (alist-get 'created_at comment)))
-               (c-body (or (alist-get 'body comment) "")))
-          (insert (format "\n### %s - %s\n" c-author c-date))
-          (insert c-body)
-          (insert "\n"))))))
-
-(defun remoto-issue-display (number repo-path)
-  "Fetch and display issue NUMBER for the repo at REPO-PATH.
-REPO-PATH is like \"/github:owner/repo\".
-Creates buffer *remoto: owner/repo#NUMBER*."
-  (unless (string-match (rx "/github:" (group (+ (not (any "/@#"))))
-                            "/" (group (+ (not (any "/@#")))))
-                        repo-path)
-    (user-error "Remoto: invalid repo path: %s" repo-path))
-  (let* ((owner (match-string 1 repo-path))
-         (repo (match-string 2 repo-path))
-         (issue (remoto--fetch-issue owner repo number)))
-    (unless issue
-      (user-error "Remoto: not found: %s/%s#%s" owner repo number))
-    (let* ((comments (remoto--fetch-issue-comments owner repo number))
-           (buf-name (format "*remoto: %s/%s#%s*" owner repo number))
-           (buf (get-buffer-create buf-name)))
-      (with-current-buffer buf
-        (let ((inhibit-read-only t))
-          (erase-buffer)
-          (remoto-issue--render issue comments))
-        (goto-char (point-min))
-        (remoto-issue-mode)
-        (setq remoto-issue--number number)
-        (setq remoto-issue--repo-path repo-path))
-      (pop-to-buffer buf)
-      buf)))
+(defun remoto--require-issue ()
+  "Load remoto-issue if not already loaded."
+  (require 'remoto-issue nil t))
 
 ;;;; Unload
 

--- a/remoto.el
+++ b/remoto.el
@@ -1934,17 +1934,30 @@ Handles candidates with prefix prepended by completion framework."
           (get-text-property (1- len) prop candidate)
           (get-text-property 0 prop candidate)))))
 
-(defun remoto--align-affixations (items)
-  "Align ITEMS for affixation display.
-ITEMS is a list of (candidate prefix suffix). Pads each candidate
-with spaces so suffixes start at the same column."
-  (let ((max-len (apply #'max 0 (mapcar (lambda (x) (length (car x))) items))))
+(defface remoto-annotation
+  '((t :inherit completions-annotations))
+  "Face for remoto completion annotations.")
+
+(defvar remoto-annotation-width-step 10
+  "Round annotation alignment width up to this step size.")
+
+(defun remoto--affixate (items)
+  "Format ITEMS as affixation triples with aligned suffixes.
+ITEMS is a list of (candidate prefix suffix).
+Uses display property for alignment (works in any completion UI)."
+  (let* ((max-len (apply #'max 0 (mapcar (lambda (x) (length (car x))) items)))
+         (align-to (* (ceiling (/ (float (+ max-len 4))
+                                  remoto-annotation-width-step))
+                      remoto-annotation-width-step)))
     (mapcar (lambda (x)
               (let* ((c (nth 0 x))
                      (prefix (nth 1 x))
-                     (suffix (nth 2 x))
-                     (pad (make-string (+ 2 (- max-len (length c))) ?\s)))
-                (list c prefix (concat pad suffix))))
+                     (suffix (nth 2 x)))
+                (list c prefix
+                      (if (string-empty-p suffix) ""
+                        (concat (propertize " " 'display
+                                            `(space :align-to ,align-to))
+                                (propertize suffix 'face 'remoto-annotation))))))
             items)))
 
 (defun remoto--completion-metadata (directory)
@@ -1960,7 +1973,7 @@ Provides group-function and affixation-function for @ and # modes."
                             "Pull Request"
                           "Issue"))))
           (affix-fn (lambda (candidates)
-                      (remoto--align-affixations
+                      (remoto--affixate
                        (mapcar (lambda (c)
                                  (let ((title (or (remoto--get-prop c 'remoto-issue-title) ""))
                                        (state (or (remoto--get-prop c 'remoto-issue-state) ""))
@@ -1986,7 +1999,7 @@ Provides group-function and affixation-function for @ and # modes."
                           (+ (not (any "/:@#"))) "/" (* nonl) eos)
                       directory))
     (let ((affix-fn (lambda (candidates)
-                      (remoto--align-affixations
+                      (remoto--affixate
                        (mapcar (lambda (c)
                                  (let ((msg (or (remoto--get-prop c 'remoto-file-commit) "")))
                                    (list c "" msg)))
@@ -1995,7 +2008,7 @@ Provides group-function and affixation-function for @ and # modes."
    ;; Owner mode: /github:OWNER/ - repo descriptions
    ((string-match (rx "/github:" (+ (not (any "/:@#"))) "/" eos) directory)
     (let ((affix-fn (lambda (candidates)
-                      (remoto--align-affixations
+                      (remoto--affixate
                        (mapcar (lambda (c)
                                  (let ((desc (or (remoto--get-prop c 'remoto-repo-desc) "")))
                                    (list c "" desc)))
@@ -2004,7 +2017,7 @@ Provides group-function and affixation-function for @ and # modes."
    ;; Root mode: /github: - user/org type
    ((equal directory "/github:")
     (let ((affix-fn (lambda (candidates)
-                      (remoto--align-affixations
+                      (remoto--affixate
                        (mapcar (lambda (c)
                                  (let* ((acct-type (or (remoto--get-prop c 'remoto-acct-type) ""))
                                         (desc (or (remoto--get-prop c 'remoto-acct-desc) ""))

--- a/remoto.el
+++ b/remoto.el
@@ -1911,7 +1911,10 @@ Args: ORIG, STRING, PRED, ACTION."
              (base (funcall orig string pred action))
              (base-alist (and (consp base) (eq (car base) 'metadata) (cdr base))))
         (if extra
-            (cons 'metadata (append extra base-alist))
+            ;; Replace category so Marginalia doesn't override our annotations
+            (cons 'metadata (append extra
+                                    `((category . remoto))
+                                    (assq-delete-all 'category (copy-alist base-alist))))
           (or base (cons 'metadata nil)))))
      ;; Non-standard action (boundaries, etc.) - pass through.
      ((not (memq action '(nil t lambda)))

--- a/remoto.el
+++ b/remoto.el
@@ -1842,6 +1842,14 @@ repo listings."
   (push (cons remoto--handler-regexp #'remoto-file-name-handler)
         file-name-handler-alist))
 
+(defun remoto--get-prop (candidate prop)
+  "Get text property PROP from CANDIDATE, searching from end.
+Handles candidates with prefix prepended by completion framework."
+  (let ((len (length candidate)))
+    (when (< 0 len)
+      (or (get-text-property (1- len) prop candidate)
+          (get-text-property 0 prop candidate)))))
+
 (defun remoto--completion-metadata (directory)
   "Return completion metadata alist for DIRECTORY, or nil.
 Provides group-function and affixation-function for @ and # modes."
@@ -1851,14 +1859,14 @@ Provides group-function and affixation-function for @ and # modes."
                   directory)
     (let ((group-fn (lambda (candidate transform)
                       (if transform candidate
-                        (if (get-text-property 0 'remoto-issue-pr candidate)
+                        (if (remoto--get-prop candidate 'remoto-issue-pr)
                             "Pull Request"
                           "Issue"))))
           (affix-fn (lambda (candidates)
                       (mapcar (lambda (c)
-                                (let ((title (or (get-text-property 0 'remoto-issue-title c) ""))
-                                      (state (or (get-text-property 0 'remoto-issue-state c) ""))
-                                      (is-pr (get-text-property 0 'remoto-issue-pr c)))
+                                (let ((title (or (remoto--get-prop c 'remoto-issue-title) ""))
+                                      (state (or (remoto--get-prop c 'remoto-issue-state) ""))
+                                      (is-pr (remoto--get-prop c 'remoto-issue-pr)))
                                   (list c
                                         (if is-pr "PR " "   ")
                                         (format " %s [%s]" title state))))
@@ -1870,7 +1878,7 @@ Provides group-function and affixation-function for @ and # modes."
                   directory)
     (let ((group-fn (lambda (candidate transform)
                       (if transform candidate
-                        (if (equal "tag" (get-text-property 0 'remoto-ref-type candidate))
+                        (if (equal "tag" (remoto--get-prop candidate 'remoto-ref-type))
                             "Tag"
                           "Branch")))))
       `((group-function . ,group-fn))))
@@ -1878,7 +1886,7 @@ Provides group-function and affixation-function for @ and # modes."
    ((string-match (rx "/github:" (+ (not (any "/:@#"))) "/" eos) directory)
     (let ((affix-fn (lambda (candidates)
                       (mapcar (lambda (c)
-                                (let ((desc (or (get-text-property 0 'remoto-repo-desc c) "")))
+                                (let ((desc (or (remoto--get-prop c 'remoto-repo-desc) "")))
                                   (list c "" (if (string-empty-p desc) ""
                                                (concat "  " desc)))))
                               candidates))))

--- a/remoto.el
+++ b/remoto.el
@@ -720,13 +720,23 @@ instead of blocking Emacs."
                     (parsed (remoto--parse-path canonical)))
                (when parsed
                  (remoto--ensure-tree parsed)
-                 (thread-last (remoto--tree-children parsed)
-                   (mapcar (lambda (child)
-                             (if (equal "tree" (alist-get 'type (cdr child)))
-                                 (concat (car child) "/")
-                               (car child))))
-                   (seq-filter (lambda (name)
-                                 (string-prefix-p file name)))))))))
+                 (let* ((children (remoto--tree-children parsed))
+                        (names (mapcar (lambda (child)
+                                         (if (equal "tree" (alist-get 'type (cdr child)))
+                                             (concat (car child) "/")
+                                           (car child)))
+                                       children))
+                        (filtered (seq-filter (lambda (name)
+                                               (string-prefix-p file name))
+                                             names))
+                        (commits (remoto--fetch-file-commits
+                                  owner repo branch subpath filtered)))
+                   (mapcar (lambda (name)
+                             (let ((msg (alist-get name commits nil nil #'equal)))
+                               (if msg
+                                   (propertize name 'remoto-file-commit msg)
+                                 name)))
+                           filtered)))))))
         ('issues
          ;; Issue/PR completion at /github:OWNER/REPO#
          (let* ((owner (plist-get partial :owner))
@@ -781,13 +791,29 @@ instead of blocking Emacs."
                           (t (> (string-to-number a) (string-to-number b))))))))))))
     ;; Full canonical path - existing behavior
     (when-let* ((parsed (remoto--parse-path directory)))
-      (thread-last (remoto--tree-children parsed)
-        (mapcar (lambda (child)
-                  (if (equal "tree" (alist-get 'type (cdr child)))
-                      (concat (car child) "/")
-                    (car child))))
-        (seq-filter (lambda (name)
-                      (string-prefix-p file name)))))))
+      (let* ((owner (remoto-path-owner parsed))
+             (repo (remoto-path-repo parsed))
+             (ref (remoto-path-ref parsed))
+             (path (remoto-path-path parsed))
+             (dir-path (if (equal path "/") ""
+                         (string-trim-left path "/")))
+             (children (remoto--tree-children parsed))
+             (names (thread-last children
+                      (mapcar (lambda (child)
+                                (if (equal "tree" (alist-get 'type (cdr child)))
+                                    (concat (car child) "/")
+                                  (car child))))
+                      (seq-filter (lambda (name)
+                                    (string-prefix-p file name)))))
+             (commits (when ref
+                        (remoto--fetch-file-commits
+                         owner repo ref dir-path names))))
+        (mapcar (lambda (name)
+                  (let ((msg (alist-get name commits nil nil #'equal)))
+                    (if msg
+                        (propertize name 'remoto-file-commit msg)
+                      name)))
+                names)))))
 
 (defun remoto--handle-file-name-completion (file directory &optional predicate)
   "Complete FILE in remote DIRECTORY using optional PREDICATE.
@@ -1448,6 +1474,44 @@ Returns list of comment alists, or nil on error."
       (remoto--api (format "repos/%s/%s/issues/%s/comments" owner repo number))
     (user-error nil)))
 
+(defvar remoto--file-commits-cache (make-hash-table :test 'equal)
+  "Cache for per-file last commit messages.
+Key: \"owner/repo@ref:dir\", Value: (TIMESTAMP . ALIST).
+ALIST maps filename -> first line of commit message.")
+
+(defun remoto--fetch-file-commits (owner repo ref dir-path children)
+  "Fetch last commit message for each file in CHILDREN.
+DIR-PATH is the directory path within OWNER/REPO at REF.
+CHILDREN is a list of filenames. Returns alist of (name . msg).
+Cached per `remoto-search-cache-ttl'. Capped at 20 API calls."
+  (let* ((key (format "%s/%s@%s:%s" owner repo ref dir-path))
+         (entry (gethash key remoto--file-commits-cache))
+         (now (float-time)))
+    (if (and entry
+             (or (zerop remoto-search-cache-ttl)
+                 (< (- now (car entry)) remoto-search-cache-ttl)))
+        (cdr entry)
+      (condition-case nil
+          (let ((result nil))
+            (dolist (child (seq-take children 20))
+              (let* ((bare-name (string-trim-right child "/"))
+                     (file-path (if (string-empty-p dir-path)
+                                    bare-name
+                                  (concat dir-path "/" bare-name)))
+                     (endpoint (format "repos/%s/%s/commits?sha=%s&path=%s&per_page=1"
+                                       owner repo
+                                       (url-hexify-string ref)
+                                       (url-hexify-string file-path)))
+                     (commits (remoto--api endpoint)))
+                (when-let* ((first (car commits))
+                            (c (alist-get 'commit first))
+                            (raw (alist-get 'message c))
+                            (msg (car (split-string raw "\n" t))))
+                  (push (cons child msg) result))))
+            (puthash key (cons now result) remoto--file-commits-cache)
+            result)
+        (user-error nil)))))
+
 (defun remoto--fetch-user-orgs (_user)
   "Fetch organization memberships for the authenticated user.
 Uses /user/orgs which includes private memberships.
@@ -1916,6 +1980,18 @@ Provides group-function and affixation-function for @ and # modes."
                             "Tag"
                           "Branch")))))
       `((group-function . ,group-fn))))
+   ;; File mode: canonical path or files-default (owner/repo/ with optional subpath)
+   ((or (string-match (rx "@" (+ (not (any ":"))) ":" (? "/")) directory)
+        (string-match (rx "/github:" (+ (not (any "/:@#"))) "/"
+                          (+ (not (any "/:@#"))) "/" (* nonl) eos)
+                      directory))
+    (let ((affix-fn (lambda (candidates)
+                      (remoto--align-affixations
+                       (mapcar (lambda (c)
+                                 (let ((msg (or (remoto--get-prop c 'remoto-file-commit) "")))
+                                   (list c "" msg)))
+                               candidates)))))
+      `((affixation-function . ,affix-fn))))
    ;; Owner mode: /github:OWNER/ - repo descriptions
    ((string-match (rx "/github:" (+ (not (any "/:@#"))) "/" eos) directory)
     (let ((affix-fn (lambda (candidates)
@@ -2014,6 +2090,7 @@ Args: ORIG, STRING, PRED, ACTION."
   (clrhash remoto--search-cache)
   (clrhash remoto--tags-cache)
   (clrhash remoto--issues-cache)
+  (clrhash remoto--file-commits-cache)
   nil)
 
 (provide 'remoto)

--- a/test/remoto-integration-tests.el
+++ b/test/remoto-integration-tests.el
@@ -36,7 +36,11 @@
   (declare (indent 0))
   `(let ((remoto--tree-cache (make-hash-table :test 'equal))
          (remoto--default-branch-cache (make-hash-table :test 'equal))
-         (remoto--content-cache (make-hash-table :test 'equal)))
+         (remoto--content-cache (make-hash-table :test 'equal))
+         (remoto--dir-contents-cache (make-hash-table :test 'equal))
+         (remoto--file-commits-cache (make-hash-table :test 'equal))
+         (remoto--auth-failed nil)
+         (remoto--authenticated-user nil))
      ,@body))
 
 ;;; Low-level API

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -1044,8 +1044,8 @@
 ;;; Partial path file operations - repo@ level
 
 (describe "repo@ level partial path operations"
-  (it "file-exists-p returns t for /github:owner/repo@"
-    (expect (remoto--handle-file-exists-p "/github:foobar/zapzop@") :to-be t))
+  (it "file-exists-p returns nil for /github:owner/repo@ (delimiter without selection)"
+    (expect (remoto--handle-file-exists-p "/github:foobar/zapzop@") :not :to-be-truthy))
 
   (it "file-directory-p returns t for /github:owner/repo@"
     (expect (remoto--handle-file-directory-p "/github:foobar/zapzop@") :to-be t))
@@ -1079,8 +1079,9 @@
       (expect (remoto--handle-file-name-nondirectory "/github:torvalds/linux@")
               :to-equal "")
 
-      ;; Step 4: /github:torvalds/linux@ + "" -> branch completions
+      ;; Step 4: /github:torvalds/linux@ + "" -> branch + tag completions
       (spy-on 'remoto--fetch-branches :and-return-value '("master" "stable"))
+      (spy-on 'remoto--fetch-tags :and-return-value nil)
       (let ((branches (remoto--handle-file-name-all-completions
                        "" "/github:torvalds/linux@")))
         (expect branches :to-equal '("master:" "stable:")))
@@ -1135,14 +1136,16 @@
     (let ((completions (remoto--handle-file-name-all-completions "lin" "/github:torvalds/")))
       (expect completions :to-equal '("linux"))))
 
-  (it "returns branch completions at repo@ directory"
+  (it "returns branch+tag completions at repo@ directory"
     (spy-on 'remoto--fetch-branches :and-return-value '("main" "develop"))
+    (spy-on 'remoto--fetch-tags :and-return-value nil)
     (let ((completions (remoto--handle-file-name-all-completions
                         "" "/github:torvalds/linux@")))
       (expect completions :to-equal '("main:" "develop:"))))
 
   (it "filters branches by prefix at repo@ directory"
     (spy-on 'remoto--fetch-branches :and-return-value '("main" "develop"))
+    (spy-on 'remoto--fetch-tags :and-return-value nil)
     (let ((completions (remoto--handle-file-name-all-completions
                         "dev" "/github:torvalds/linux@")))
       (expect completions :to-equal '("develop:"))))
@@ -1208,6 +1211,630 @@
 
   (it "leaves non-github paths unchanged"
     (expect (remoto--maybe-rewrite "/home/user/file") :to-equal "/home/user/file")))
+
+;;; ====================================================================
+;;; TDD tests for v2 features: delimiter dispatch, #issues, @tags,
+;;; files-default, file-exists-p tightening, edge cases
+;;; ====================================================================
+
+;;; E2E test helper
+
+(defun remoto-test--complete (input)
+  "Simulate completion for INPUT, return candidates.
+Exercises the full chain: file-name-directory -> file-name-nondirectory
+-> file-name-all-completions."
+  (let* ((dir (remoto-file-name-handler 'file-name-directory input))
+         (file (remoto-file-name-handler 'file-name-nondirectory input))
+         (completions (remoto-file-name-handler
+                       'file-name-all-completions file dir)))
+    completions))
+
+(defun remoto-test--tab-complete (input)
+  "Simulate TAB completion for INPUT, return completed string.
+Returns the full path after completion, or INPUT if no completion."
+  (let* ((dir (remoto-file-name-handler 'file-name-directory input))
+         (file (remoto-file-name-handler 'file-name-nondirectory input))
+         (completion (remoto-file-name-handler
+                      'file-name-completion file dir)))
+    (if (and completion (stringp completion))
+        (concat dir completion)
+      input)))
+
+;;; ---- Partial path parsing: new levels ----
+
+(describe "remoto--parse-partial-github-path new levels"
+  ;; files-default: /github:owner/repo/
+  (it "parses /github:owner/repo/ as files-default level"
+    (let ((result (remoto--parse-partial-github-path "/github:foobar/zapato/")))
+      (expect (plist-get result :level) :to-equal 'files-default)
+      (expect (plist-get result :owner) :to-equal "foobar")
+      (expect (plist-get result :repo) :to-equal "zapato")))
+
+  (it "parses /github:owner/repo/subdir/ as files-default level"
+    (let ((result (remoto--parse-partial-github-path "/github:foobar/zapato/src/")))
+      (expect (plist-get result :level) :to-equal 'files-default)
+      (expect (plist-get result :owner) :to-equal "foobar")
+      (expect (plist-get result :repo) :to-equal "zapato")))
+
+  ;; issues: /github:owner/repo#
+  (it "parses /github:owner/repo# as issues level"
+    (let ((result (remoto--parse-partial-github-path "/github:foobar/zapato#")))
+      (expect (plist-get result :level) :to-equal 'issues)
+      (expect (plist-get result :owner) :to-equal "foobar")
+      (expect (plist-get result :repo) :to-equal "zapato")))
+
+  ;; delimiter without repo - invalid
+  (it "returns nil for /github:owner# (no repo)"
+    (expect (remoto--parse-partial-github-path "/github:foobar#") :to-be nil))
+
+  (it "returns nil for /github:owner@ (no repo)"
+    (expect (remoto--parse-partial-github-path "/github:foobar@") :to-be nil))
+
+  ;; repo with special characters
+  (it "parses repo with dots"
+    (let ((result (remoto--parse-partial-github-path "/github:agzam/remoto.el#")))
+      (expect (plist-get result :level) :to-equal 'issues)
+      (expect (plist-get result :repo) :to-equal "remoto.el")))
+
+  (it "parses repo with hyphens"
+    (let ((result (remoto--parse-partial-github-path "/github:foo/my-repo@")))
+      (expect (plist-get result :level) :to-equal 'repo)
+      (expect (plist-get result :repo) :to-equal "my-repo")))
+
+  (it "parses repo with underscores"
+    (let ((result (remoto--parse-partial-github-path "/github:foo/my_repo/")))
+      (expect (plist-get result :level) :to-equal 'files-default)
+      (expect (plist-get result :repo) :to-equal "my_repo")))
+
+  ;; empty/degenerate segments
+  (it "returns nil for /github:/"
+    (expect (remoto--parse-partial-github-path "/github:/") :to-be nil))
+
+  (it "returns nil for /github://"
+    (expect (remoto--parse-partial-github-path "/github://") :to-be nil))
+
+  (it "returns nil for /github:foo/#"
+    (expect (remoto--parse-partial-github-path "/github:foo/#") :to-be nil))
+
+  (it "returns nil for /github:foo/# (empty repo before #)"
+    (expect (remoto--parse-partial-github-path "/github:foo/#") :to-be nil))
+
+  ;; existing levels still work
+  (it "still parses /github: as root"
+    (let ((result (remoto--parse-partial-github-path "/github:")))
+      (expect (plist-get result :level) :to-equal 'root)))
+
+  (it "still parses /github:owner/ as owner"
+    (let ((result (remoto--parse-partial-github-path "/github:foobar/")))
+      (expect (plist-get result :level) :to-equal 'owner)))
+
+  (it "still parses /github:owner/repo@ as repo (branches)"
+    (let ((result (remoto--parse-partial-github-path "/github:foobar/zapato@")))
+      (expect (plist-get result :level) :to-equal 'repo))))
+
+;;; ---- file-name-directory with # delimiter ----
+
+(describe "file-name-directory with # delimiter"
+  (it "returns /github:owner/repo# for /github:owner/repo#"
+    (expect (remoto--handle-file-name-directory "/github:foobar/zapato#")
+            :to-equal "/github:foobar/zapato#"))
+
+  (it "returns /github:owner/repo# for /github:owner/repo#42"
+    (expect (remoto--handle-file-name-directory "/github:foobar/zapato#42")
+            :to-equal "/github:foobar/zapato#"))
+
+  (it "returns /github:owner/repo# for /github:owner/repo#fix-bug"
+    (expect (remoto--handle-file-name-directory "/github:foobar/zapato#fix-bug")
+            :to-equal "/github:foobar/zapato#"))
+
+  ;; # without repo - treat as part of owner query
+  (it "returns /github: for /github:foo#"
+    (expect (remoto--handle-file-name-directory "/github:foo#")
+            :to-equal "/github:"))
+
+  ;; existing @ behavior unchanged
+  (it "still handles /github:owner/repo@ correctly"
+    (expect (remoto--handle-file-name-directory "/github:foobar/zapato@")
+            :to-equal "/github:foobar/zapato@"))
+
+  (it "still handles /github:owner/repo@branch correctly"
+    (expect (remoto--handle-file-name-directory "/github:foobar/zapato@main")
+            :to-equal "/github:foobar/zapato@")))
+
+;;; ---- file-name-nondirectory with # delimiter ----
+
+(describe "file-name-nondirectory with # delimiter"
+  (it "returns empty for /github:owner/repo#"
+    (expect (remoto--handle-file-name-nondirectory "/github:foobar/zapato#")
+            :to-equal ""))
+
+  (it "returns 42 for /github:owner/repo#42"
+    (expect (remoto--handle-file-name-nondirectory "/github:foobar/zapato#42")
+            :to-equal "42"))
+
+  (it "returns fix-bug for /github:owner/repo#fix-bug"
+    (expect (remoto--handle-file-name-nondirectory "/github:foobar/zapato#fix-bug")
+            :to-equal "fix-bug"))
+
+  ;; # without repo - not a valid delimiter, part of owner query
+  (it "returns foo# for /github:foo# (no repo, literal)"
+    (expect (remoto--handle-file-name-nondirectory "/github:foo#")
+            :to-equal "foo#"))
+
+  ;; existing @ behavior unchanged
+  (it "still returns empty for /github:owner/repo@"
+    (expect (remoto--handle-file-name-nondirectory "/github:foobar/zapato@")
+            :to-equal ""))
+
+  (it "still returns branch for /github:owner/repo@branch"
+    (expect (remoto--handle-file-name-nondirectory "/github:foobar/zapato@main")
+            :to-equal "main")))
+
+;;; ---- file-name-directory/nondirectory for files-default ----
+
+(describe "file-name-directory for files-default (short form)"
+  (it "returns /github:owner/repo/ for /github:owner/repo/"
+    (expect (remoto--handle-file-name-directory "/github:foobar/zapato/")
+            :to-equal "/github:foobar/zapato/"))
+
+  (it "returns /github:owner/repo/ for /github:owner/repo/src"
+    (expect (remoto--handle-file-name-directory "/github:foobar/zapato/src")
+            :to-equal "/github:foobar/zapato/"))
+
+  (it "returns /github:owner/repo/src/ for /github:owner/repo/src/"
+    (expect (remoto--handle-file-name-directory "/github:foobar/zapato/src/")
+            :to-equal "/github:foobar/zapato/src/"))
+
+  (it "returns /github:owner/repo/src/ for /github:owner/repo/src/file.el"
+    (expect (remoto--handle-file-name-directory "/github:foobar/zapato/src/file.el")
+            :to-equal "/github:foobar/zapato/src/")))
+
+(describe "file-name-nondirectory for files-default (short form)"
+  (it "returns empty for /github:owner/repo/"
+    (expect (remoto--handle-file-name-nondirectory "/github:foobar/zapato/")
+            :to-equal ""))
+
+  (it "returns src for /github:owner/repo/src"
+    (expect (remoto--handle-file-name-nondirectory "/github:foobar/zapato/src")
+            :to-equal "src"))
+
+  (it "returns file.el for /github:owner/repo/src/file.el"
+    (expect (remoto--handle-file-name-nondirectory "/github:foobar/zapato/src/file.el")
+            :to-equal "file.el")))
+
+;;; ---- file-exists-p tightening ----
+
+(describe "file-exists-p tightened for non-openable paths"
+  ;; Should return nil (not openable)
+  (it "returns nil for bare /github:owner/repo (no delimiter)"
+    (expect (remoto--handle-file-exists-p "/github:foobar/zapato")
+            :not :to-be-truthy))
+
+  (it "returns nil for /github:owner# (no repo)"
+    (expect (remoto--handle-file-exists-p "/github:foobar#")
+            :not :to-be-truthy))
+
+  (it "returns nil for /github:owner@ (no repo)"
+    (expect (remoto--handle-file-exists-p "/github:foobar@")
+            :not :to-be-truthy))
+
+  (it "returns nil for /github:owner/repo# (delimiter without selection)"
+    (expect (remoto--handle-file-exists-p "/github:foobar/zapato#")
+            :not :to-be-truthy))
+
+  (it "returns nil for /github:owner/repo@ (delimiter without selection)"
+    (expect (remoto--handle-file-exists-p "/github:foobar/zapato@")
+            :not :to-be-truthy))
+
+  ;; Should return t (openable)
+  (it "returns t for /github:"
+    (expect (remoto--handle-file-exists-p "/github:") :to-be t))
+
+  (it "returns t for /github:owner/"
+    (expect (remoto--handle-file-exists-p "/github:foobar/") :to-be t))
+
+  (it "returns t for /github:owner/repo/ (files-default, openable as dired)"
+    (expect (remoto--handle-file-exists-p "/github:foobar/zapato/") :to-be t))
+
+  (it "returns t for existing canonical file"
+    (remoto-test-with-cache
+      (expect (remoto--handle-file-exists-p
+               "/github:testowner/testrepo@main:/README.md")
+              :to-be t)))
+
+  (it "returns t for /github:owner/repo#42 (specific issue ref)"
+    (expect (remoto--handle-file-exists-p "/github:foobar/zapato#42")
+            :to-be t)))
+
+;;; ---- Completion: files-default level ----
+
+(describe "completion at files-default level"
+  (it "lists root files for /github:owner/repo/"
+    (remoto-test-with-cache
+      (spy-on 'remoto--default-branch :and-return-value "main")
+      (let ((completions (remoto--handle-file-name-all-completions
+                          "" "/github:testowner/testrepo/")))
+        (expect (member "README.md" completions) :to-be-truthy)
+        (expect (member "src/" completions) :to-be-truthy)
+        (expect (member "bin/" completions) :to-be-truthy))))
+
+  (it "filters root files by prefix"
+    (remoto-test-with-cache
+      (spy-on 'remoto--default-branch :and-return-value "main")
+      (let ((completions (remoto--handle-file-name-all-completions
+                          "s" "/github:testowner/testrepo/")))
+        (expect (member "src/" completions) :to-be-truthy)
+        (expect (member "README.md" completions) :not :to-be-truthy))))
+
+  (it "lists subdirectory files"
+    (remoto-test-with-cache
+      (spy-on 'remoto--default-branch :and-return-value "main")
+      (let ((completions (remoto--handle-file-name-all-completions
+                          "" "/github:testowner/testrepo/src/")))
+        (expect (member "main.el" completions) :to-be-truthy)
+        (expect (member "utils.el" completions) :to-be-truthy))))
+
+  (it "returns empty for nonexistent subdirectory"
+    (remoto-test-with-cache
+      (spy-on 'remoto--default-branch :and-return-value "main")
+      (let ((completions (remoto--handle-file-name-all-completions
+                          "" "/github:testowner/testrepo/nope/")))
+        (expect completions :to-be nil))))
+
+  (it "returns empty when default branch resolution fails"
+    (remoto-test-with-cache
+      (spy-on 'remoto--default-branch :and-return-value nil)
+      (let ((completions (remoto--handle-file-name-all-completions
+                          "" "/github:testowner/testrepo/")))
+        (expect completions :to-be nil)))))
+
+;;; ---- Completion: issues level ----
+
+(describe "completion at issues level"
+  (it "lists issues/PRs for /github:owner/repo#"
+    (spy-on 'remoto--fetch-issues :and-return-value
+            '(((number . 42) (title . "Fix parser bug") (pull_request))
+              ((number . 10) (title . "Add docs"))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (let ((completions (remoto--handle-file-name-all-completions
+                          "" "/github:foobar/zapato#")))
+        (expect (member "42" completions) :to-be-truthy)
+        (expect (member "10" completions) :to-be-truthy))))
+
+  (it "filters issues by text search"
+    (spy-on 'remoto--search-issues :and-return-value
+            '(((number . 42) (title . "Fix parser bug") (pull_request))
+              ((number . 99) (title . "Fix typo"))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (let ((completions (remoto--handle-file-name-all-completions
+                          "fix" "/github:foobar/zapato#")))
+        (expect (member "42" completions) :to-be-truthy)
+        (expect (member "99" completions) :to-be-truthy))))
+
+  (it "returns direct issue for numeric query"
+    (spy-on 'remoto--fetch-issue :and-return-value
+            '((number . 42) (title . "Fix parser bug")))
+    (spy-on 'remoto--fetch-issues :and-return-value
+            '(((number . 1) (title . "First issue"))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (let ((completions (remoto--handle-file-name-all-completions
+                          "42" "/github:foobar/zapato#")))
+        (expect (member "42" completions) :to-be-truthy))))
+
+  (it "returns empty when repo returns 404"
+    (spy-on 'remoto--fetch-issues :and-return-value nil)
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (let ((completions (remoto--handle-file-name-all-completions
+                          "" "/github:foobar/nonexistent#")))
+        (expect completions :to-be nil))))
+
+  (it "returns empty for /github:owner# (no repo)"
+    (let ((completions (remoto-test--complete "/github:foobar#")))
+      (expect completions :to-be nil))))
+
+;;; ---- Completion: branches + tags grouped ----
+
+(describe "completion at @ level with branches and tags"
+  (it "returns both branches and tags"
+    (spy-on 'remoto--fetch-branches :and-return-value '("main" "develop"))
+    (spy-on 'remoto--fetch-tags :and-return-value '("v1.0.0" "v2.0.0"))
+    (let ((completions (remoto--handle-file-name-all-completions
+                        "" "/github:foobar/zapato@")))
+      (expect (member "main:" completions) :to-be-truthy)
+      (expect (member "develop:" completions) :to-be-truthy)
+      (expect (member "v1.0.0:" completions) :to-be-truthy)
+      (expect (member "v2.0.0:" completions) :to-be-truthy)))
+
+  (it "filters branches and tags by prefix"
+    (spy-on 'remoto--fetch-branches :and-return-value '("main" "develop"))
+    (spy-on 'remoto--fetch-tags :and-return-value '("v1.0.0" "v2.0.0"))
+    (let ((completions (remoto--handle-file-name-all-completions
+                        "v" "/github:foobar/zapato@")))
+      (expect (member "main:" completions) :not :to-be-truthy)
+      (expect (member "v1.0.0:" completions) :to-be-truthy)
+      (expect (member "v2.0.0:" completions) :to-be-truthy)))
+
+  (it "returns empty when both branches and tags fail"
+    (spy-on 'remoto--fetch-branches :and-return-value nil)
+    (spy-on 'remoto--fetch-tags :and-return-value nil)
+    (let ((completions (remoto--handle-file-name-all-completions
+                        "" "/github:foobar/zapato@")))
+      (expect completions :to-be nil))))
+
+;;; ---- E2E completion scenarios ----
+
+(describe "E2E completion: happy paths"
+  (it "owner -> repo -> files (default branch)"
+    (remoto-test-with-cache
+      ;; Step 1: find user
+      (spy-on 'remoto--search-users :and-return-value '("testowner"))
+      (expect (remoto-test--complete "/github:test")
+              :to-equal '("testowner/"))
+
+      ;; Step 2: find repo
+      (spy-on 'remoto--recent-owner-repos :and-return-value '("testrepo"))
+      (expect (remoto-test--complete "/github:testowner/")
+              :to-equal '("testrepo"))
+
+      ;; Step 3: list files on default branch
+      (spy-on 'remoto--default-branch :and-return-value "main")
+      (let ((completions (remoto-test--complete "/github:testowner/testrepo/")))
+        (expect (member "README.md" completions) :to-be-truthy)
+        (expect (member "src/" completions) :to-be-truthy))))
+
+  (it "owner -> repo -> # -> issues"
+    (spy-on 'remoto--fetch-issues :and-return-value
+            '(((number . 5) (title . "Bug report") (pull_request))
+              ((number . 3) (title . "Feature request"))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (let ((completions (remoto-test--complete "/github:foobar/zapato#")))
+        (expect (member "5" completions) :to-be-truthy)
+        (expect (member "3" completions) :to-be-truthy))))
+
+  (it "owner -> repo -> @ -> branches+tags -> files"
+    (remoto-test-with-cache
+      ;; Branch listing includes tags
+      (spy-on 'remoto--fetch-branches :and-return-value '("main" "develop"))
+      (spy-on 'remoto--fetch-tags :and-return-value '("v1.0"))
+      (let ((completions (remoto-test--complete "/github:testowner/testrepo@")))
+        (expect (member "main:" completions) :to-be-truthy)
+        (expect (member "v1.0:" completions) :to-be-truthy))
+
+      ;; After selecting branch, list files
+      (let ((completions (remoto-test--complete "/github:testowner/testrepo@main:/")))
+        (expect (member "src/" completions) :to-be-truthy)))))
+
+(describe "E2E completion: edge cases"
+  ;; Delimiter without repo
+  (it "returns nil for /github:foo#"
+    (expect (remoto-test--complete "/github:foo#") :to-be nil))
+
+  (it "returns nil for /github:foo@"
+    (expect (remoto-test--complete "/github:foo@") :to-be nil))
+
+  (it "returns nil for /github:foo#42"
+    (expect (remoto-test--complete "/github:foo#42") :to-be nil))
+
+  ;; Nonexistent resources
+  (it "returns nil for nonexistent repo issues"
+    (spy-on 'remoto--fetch-issues :and-return-value nil)
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (expect (remoto-test--complete "/github:foo/nonexistent#") :to-be nil)))
+
+  ;; Double slash normalization
+  (it "handles /github:foo//bar gracefully"
+    (spy-on 'remoto--search-owner-repos :and-return-value '("bar"))
+    ;; Double slash should normalize - file-name-directory handles it
+    (let ((dir (remoto--handle-file-name-directory "/github:foo//bar")))
+      (expect dir :to-be-truthy)))
+
+  ;; Mixed delimiters - first after repo wins
+  (it "/github:foo/bar/@ treats @ as literal file char"
+    (remoto-test-with-cache
+      (spy-on 'remoto--default-branch :and-return-value "main")
+      ;; In files-default mode, @ is a literal filename character
+      (let ((dir (remoto--handle-file-name-directory "/github:testowner/testrepo/@")))
+        (expect dir :to-equal "/github:testowner/testrepo/"))))
+
+  (it "/github:foo/bar@# treats # as literal branch char"
+    ;; In branch mode, # is part of branch name query
+    (expect (remoto--handle-file-name-directory "/github:foo/bar@#")
+            :to-equal "/github:foo/bar@")
+    (expect (remoto--handle-file-name-nondirectory "/github:foo/bar@#")
+            :to-equal "#"))
+
+  (it "/github:foo/bar## treats second # as literal"
+    ;; First # is delimiter, second is part of query
+    (expect (remoto--handle-file-name-directory "/github:foo/bar##")
+            :to-equal "/github:foo/bar#")
+    (expect (remoto--handle-file-name-nondirectory "/github:foo/bar##")
+            :to-equal "#"))
+
+  ;; Case insensitivity
+  (it "handles uppercase owner/repo"
+    (spy-on 'remoto--fetch-issues :and-return-value
+            '(((number . 1) (title . "Test"))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (let ((completions (remoto-test--complete "/github:FOO/BAR#")))
+        (expect (member "1" completions) :to-be-truthy))))
+
+  ;; Repo with dots
+  (it "handles repo with dots in issues mode"
+    (spy-on 'remoto--fetch-issues :and-return-value
+            '(((number . 7) (title . "Setup"))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (let ((completions (remoto-test--complete "/github:agzam/remoto.el#")))
+        (expect (member "7" completions) :to-be-truthy))))
+
+  ;; Empty /github:
+  (it "/github: with empty query returns nil (current behavior)"
+    (let ((completions (remoto-test--complete "/github:")))
+      (expect completions :to-be nil))))
+
+;;; ---- TAB completion behavior ----
+
+(describe "TAB completion at each level"
+  (it "completes unique owner with /"
+    (spy-on 'remoto--search-users :and-return-value '("torvalds"))
+    (expect (remoto-test--tab-complete "/github:tor")
+            :to-equal "/github:torvalds/"))
+
+  (it "completes common owner prefix"
+    (spy-on 'remoto--search-users :and-return-value '("torvalds" "torgeirhelge"))
+    (expect (remoto-test--tab-complete "/github:tor")
+            :to-equal "/github:tor"))
+
+  (it "completes unique repo"
+    (spy-on 'remoto--search-owner-repos :and-return-value '("linux"))
+    (expect (remoto-test--tab-complete "/github:torvalds/lin")
+            :to-equal "/github:torvalds/linux"))
+
+  (it "completes unique branch with :"
+    (spy-on 'remoto--fetch-branches :and-return-value '("main"))
+    (spy-on 'remoto--fetch-tags :and-return-value nil)
+    (expect (remoto-test--tab-complete "/github:foo/bar@ma")
+            :to-equal "/github:foo/bar@main:"))
+
+  (it "completes unique issue number"
+    (spy-on 'remoto--fetch-issues :and-return-value
+            '(((number . 42) (title . "Bug"))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (expect (remoto-test--tab-complete "/github:foo/bar#4")
+              :to-equal "/github:foo/bar#42")))
+
+  (it "returns input unchanged when no matches"
+    (spy-on 'remoto--search-users :and-return-value nil)
+    (expect (remoto-test--tab-complete "/github:zzz")
+            :to-equal "/github:zzz")))
+
+;;; ---- file-exists-p for RET behavior ----
+
+(describe "file-exists-p RET guard scenarios"
+  ;; These paths should trigger [Confirm] in the minibuffer
+  ;; because file-exists-p returns nil
+  (it "bare owner/repo triggers confirm (nil)"
+    (expect (remoto--handle-file-exists-p "/github:foo/bar")
+            :not :to-be-truthy))
+
+  (it "delimiter without selection triggers confirm (nil)"
+    (expect (remoto--handle-file-exists-p "/github:foo/bar#")
+            :not :to-be-truthy)
+    (expect (remoto--handle-file-exists-p "/github:foo/bar@")
+            :not :to-be-truthy))
+
+  (it "delimiter without repo triggers confirm (nil)"
+    (expect (remoto--handle-file-exists-p "/github:foo#")
+            :not :to-be-truthy)
+    (expect (remoto--handle-file-exists-p "/github:foo@")
+            :not :to-be-truthy))
+
+  ;; These should NOT trigger confirm
+  (it "specific issue ref does not trigger confirm"
+    (expect (remoto--handle-file-exists-p "/github:foo/bar#42")
+            :to-be t))
+
+  (it "repo with trailing / does not trigger confirm"
+    (expect (remoto--handle-file-exists-p "/github:foo/bar/")
+            :to-be t))
+
+  (it "canonical file path does not trigger confirm"
+    (remoto-test-with-cache
+      (expect (remoto--handle-file-exists-p
+               "/github:testowner/testrepo@main:/README.md")
+              :to-be t))))
+
+;;; ---- Error handling during completion ----
+
+(describe "error handling during completion"
+  (it "API error during issue listing returns nil"
+    (spy-on 'remoto--fetch-issues :and-return-value nil)
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (let ((completions (remoto--handle-file-name-all-completions
+                          "" "/github:foo/bar#")))
+        (expect completions :to-be nil))))
+
+  (it "API error during branch listing returns nil"
+    (spy-on 'remoto--fetch-branches :and-return-value nil)
+    (spy-on 'remoto--fetch-tags :and-return-value nil)
+    (let ((completions (remoto--handle-file-name-all-completions
+                        "" "/github:foo/bar@")))
+      (expect completions :to-be nil)))
+
+  (it "API error during files-default listing returns nil"
+    (remoto-test-with-cache
+      (spy-on 'remoto--default-branch :and-return-value nil)
+      (let ((completions (remoto--handle-file-name-all-completions
+                          "" "/github:foo/bar/")))
+        (expect completions :to-be nil)))))
+
+;;; ---- Path normalization on open ----
+
+(describe "path normalization for files-default"
+  (it "rewrites /github:owner/repo/ to canonical form"
+    (let ((remoto--default-branch-cache (make-hash-table :test 'equal)))
+      (puthash "foobar/zapato" "main" remoto--default-branch-cache)
+      (expect (remoto--maybe-rewrite "/github:foobar/zapato/")
+              :to-equal "/github:foobar/zapato@main:/")))
+
+  (it "rewrites /github:owner/repo/path to canonical form"
+    (let ((remoto--default-branch-cache (make-hash-table :test 'equal)))
+      (puthash "foobar/zapato" "main" remoto--default-branch-cache)
+      (expect (remoto--maybe-rewrite "/github:foobar/zapato/src/main.el")
+              :to-equal "/github:foobar/zapato@main:/src/main.el"))))
+
+;;; ---- Issue/PR opening via #NUM ----
+
+(describe "opening issues via #NUM"
+  (it "detects #NUM pattern in find-file-noselect advice"
+    ;; When /github:owner/repo#42 is passed to find-file-noselect,
+    ;; it should NOT try to open as a regular file.
+    ;; Instead it should call remoto-issue-display.
+    (spy-on 'remoto-issue-display)
+    (spy-on 'remoto--maybe-rewrite :and-return-value "/github:foo/bar#42")
+    ;; Simulate what the advice does
+    (let ((filename "/github:foo/bar#42"))
+      (when (string-match (rx "#" (group (+ digit)) eos) filename)
+        (remoto-issue-display
+         (match-string 1 filename)
+         (substring filename 0 (match-beginning 0)))))
+    (expect 'remoto-issue-display :to-have-been-called)))
+
+;;; ---- Root completion enhancement ----
+
+(describe "root completion with user orgs"
+  (it "shows user orgs when authenticated and query is empty"
+    (spy-on 'remoto--fetch-user-orgs :and-return-value '("qlik-oss" "nebula-contrib"))
+    (let ((remoto--authenticated-user "agzam"))
+      (let ((completions (remoto--handle-file-name-all-completions "" "/github:")))
+        (expect (member "agzam/" completions) :to-be-truthy)
+        (expect (member "qlik-oss/" completions) :to-be-truthy)
+        (expect (member "nebula-contrib/" completions) :to-be-truthy))))
+
+  (it "falls back to nil when not authenticated"
+    (let ((remoto--authenticated-user nil))
+      (spy-on 'remoto--search-users :and-return-value nil)
+      (let ((completions (remoto--handle-file-name-all-completions "" "/github:")))
+        (expect completions :to-be nil)))))
+
+;;; ---- Issue cache ----
+
+(describe "issue cache"
+  (it "caches issue listing results"
+    (let ((remoto--issues-cache (make-hash-table :test 'equal))
+          (call-count 0))
+      (spy-on 'remoto--api :and-call-fake
+              (lambda (_endpoint)
+                (setq call-count (1+ call-count))
+                '(((number . 1) (title . "Bug")))))
+      (remoto--fetch-issues "foo" "bar")
+      (remoto--fetch-issues "foo" "bar")
+      (expect call-count :to-equal 1)))
+
+  (it "returns nil on API error"
+    (spy-on 'remoto--api :and-call-fake
+            (lambda (_) (user-error "not found")))
+    (let ((remoto--issues-cache (make-hash-table :test 'equal)))
+      (expect (remoto--fetch-issues "foo" "nonexistent") :to-be nil))))
 
 (provide 'remoto-tests)
 

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -1920,18 +1920,21 @@ Returns the full path after completion, or INPUT if no completion."
       ;; that completion-metadata returns our custom metadata
       (expect (remoto--completion-metadata directory) :not :to-be nil))))
 
-;;; ---- remoto--align-affixations ----
+;;; ---- remoto--affixate ----
 
 (describe "annotation alignment"
-  (it "pads suffixes to align at same column"
+  (it "uses display property for alignment"
     (let ((items '(("short" "" "desc1")
                    ("a-much-longer-name" "" "desc2"))))
-      (let ((result (remoto--align-affixations items)))
-        ;; Both suffixes should start at same position relative to candidate end
-        ;; The short one should have more padding
-        (expect (length (nth 2 (car result)))
-                :to-be-greater-than
-                (length (nth 2 (cadr result))))))))
+      (let ((result (remoto--affixate items)))
+        ;; Both suffixes use (space :align-to N) display property
+        (expect (get-text-property 0 'display (nth 2 (car result)))
+                :to-be-truthy)
+        (expect (get-text-property 0 'display (nth 2 (cadr result)))
+                :to-be-truthy)
+        ;; Suffix text has face applied
+        (expect (get-text-property 1 'face (nth 2 (car result)))
+                :to-equal 'remoto-annotation)))))
 
 ;;; ---- PR ordering in issue completion ----
 

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -39,6 +39,9 @@
          (remoto--branches-cache (make-hash-table :test 'equal))
          (remoto--search-cache (make-hash-table :test 'equal))
          (remoto--users-cache (make-hash-table :test 'equal))
+         (remoto--dir-contents-cache (make-hash-table :test 'equal))
+         (remoto--file-commits-cache (make-hash-table :test 'equal))
+         (remoto--auth-failed nil)
          (remoto--authenticated-user nil))
      (puthash "testowner/testrepo" "main" remoto--default-branch-cache)
      (remoto-test--install-mock-tree)
@@ -707,9 +710,185 @@
     (let ((result (remoto--repo-completion-table "torvalds" nil t)))
       (expect result :to-equal '("torvalds/linux" "torvalds/subsurface"))))
 
-  (it "returns metadata"
-    (expect (remoto--repo-completion-table "" nil 'metadata)
-            :to-equal '(metadata (category . remoto-repo)))))
+  (it "returns metadata with category for plain search"
+    (let ((meta (remoto--repo-completion-table "" nil 'metadata)))
+      (expect (alist-get 'category (cdr meta)) :to-equal 'remoto-browse)))
+
+  (it "returns issue metadata for # mode"
+    (let ((meta (remoto--repo-completion-table "foo/bar#" nil 'metadata)))
+      (expect (alist-get 'group-function (cdr meta)) :to-be-truthy)
+      (expect (alist-get 'affixation-function (cdr meta)) :to-be-truthy)))
+
+  (it "returns branch metadata for @ mode"
+    (let ((meta (remoto--repo-completion-table "foo/bar@" nil 'metadata)))
+      (expect (alist-get 'group-function (cdr meta)) :to-be-truthy)))
+
+  (it "returns issue completions for # delimiter"
+    (spy-on 'remoto--fetch-issues :and-return-value
+            '(((number . 42) (title . "Fix bug") (state . "open"))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (let ((result (remoto--repo-completion-table "foo/bar#" nil t)))
+        (expect (length result) :to-equal 1)
+        (expect (car result) :to-match "#42"))))
+
+  (it "returns branch completions for @ delimiter"
+    (spy-on 'remoto--fetch-branches :and-return-value '("main" "develop"))
+    (spy-on 'remoto--fetch-tags :and-return-value '("v1.0"))
+    (let ((result (remoto--repo-completion-table "foo/bar@" nil t)))
+      (expect (length result) :to-equal 3)
+      (expect (seq-some (lambda (r) (string-match-p "@main" r)) result) :to-be-truthy)
+      (expect (seq-some (lambda (r) (string-match-p "@v1.0" r)) result) :to-be-truthy)))
+
+  (it "filters branches by prefix after @"
+    (spy-on 'remoto--fetch-branches :and-return-value '("main" "develop"))
+    (spy-on 'remoto--fetch-tags :and-return-value nil)
+    (let ((result (remoto--repo-completion-table "foo/bar@dev" nil t)))
+      (expect (length result) :to-equal 1)
+      (expect (car result) :to-match "@develop")))
+
+  (it "issue completions carry text properties"
+    (spy-on 'remoto--fetch-issues :and-return-value
+            '(((number . 99) (title . "Important PR") (state . "open")
+               (pull_request (url . "http://...")))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (let* ((result (remoto--repo-completion-table "foo/bar#" nil t))
+             (c (car result)))
+        (expect (get-text-property 0 'remoto-topic-pr c) :to-be-truthy)
+        (expect (get-text-property 0 'remoto-topic-title c) :to-equal "Important PR"))))
+
+  (it "returns file completions for / delimiter"
+    (spy-on 'remoto--default-branch :and-return-value "main")
+    (spy-on 'remoto--fetch-dir-children-light :and-return-value
+            '(("README.md" . ((type . "blob") (size . 500)))
+              ("src" . ((type . "tree") (size . 0)))))
+    (let ((result (remoto--repo-completion-table "foo/bar/" nil t)))
+      (expect (length result) :to-equal 2)
+      (expect (seq-some (lambda (r) (string-suffix-p "README.md" r)) result)
+              :to-be-truthy)
+      (expect (seq-some (lambda (r) (string-suffix-p "src/" r)) result)
+              :to-be-truthy)))
+
+  (it "search results carry repo descriptions"
+    (spy-on 'remoto--api :and-return-value
+            '((items . (((full_name . "torvalds/linux")
+                         (description . "Linux kernel"))))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (let ((result (remoto--repo-completion-table "torvalds" nil t)))
+        (expect (car result) :to-equal "torvalds/linux")
+        (expect (get-text-property 0 'remoto-repo-desc (car result))
+                :to-equal "Linux kernel")))))
+
+(describe "remoto--browse-parse-input"
+  (it "parses plain search"
+    (pcase-let ((`(,mode ,owner ,repo ,query)
+                 (remoto--browse-parse-input "torvalds")))
+      (expect mode :to-equal 'search)
+      (expect owner :to-be nil)
+      (expect query :to-equal "torvalds")))
+
+  (it "parses @ mode"
+    (pcase-let ((`(,mode ,owner ,repo ,query)
+                 (remoto--browse-parse-input "foo/bar@main")))
+      (expect mode :to-equal 'branches)
+      (expect owner :to-equal "foo")
+      (expect repo :to-equal "bar")
+      (expect query :to-equal "main")))
+
+  (it "parses # mode"
+    (pcase-let ((`(,mode ,owner ,repo ,query)
+                 (remoto--browse-parse-input "foo/bar#42")))
+      (expect mode :to-equal 'issues)
+      (expect owner :to-equal "foo")
+      (expect repo :to-equal "bar")
+      (expect query :to-equal "42")))
+
+  (it "parses empty # query"
+    (pcase-let ((`(,mode ,_o ,_r ,query)
+                 (remoto--browse-parse-input "foo/bar#")))
+      (expect mode :to-equal 'issues)
+      (expect query :to-equal "")))
+
+  (it "parses empty @ query"
+    (pcase-let ((`(,mode ,_o ,_r ,query)
+                 (remoto--browse-parse-input "foo/bar@")))
+      (expect mode :to-equal 'branches)
+      (expect query :to-equal "")))
+
+  (it "parses / mode"
+    (pcase-let ((`(,mode ,owner ,repo ,query)
+                 (remoto--browse-parse-input "foo/bar/")))
+      (expect mode :to-equal 'files)
+      (expect owner :to-equal "foo")
+      (expect repo :to-equal "bar")
+      (expect query :to-equal "")))
+
+  (it "parses / mode with subpath"
+    (pcase-let ((`(,mode ,owner ,repo ,query)
+                 (remoto--browse-parse-input "foo/bar/src/main.el")))
+      (expect mode :to-equal 'files)
+      (expect owner :to-equal "foo")
+      (expect repo :to-equal "bar")
+      (expect query :to-equal "src/main.el")))
+
+  (it "handles repo with dots in # mode"
+    (pcase-let ((`(,mode ,owner ,repo ,query)
+                 (remoto--browse-parse-input "agzam/remoto.el#")))
+      (expect mode :to-equal 'issues)
+      (expect repo :to-equal "remoto.el"))))
+
+(describe "remoto--require-topic"
+  (it "loads remoto-topic from the package directory"
+    (let ((loaded nil))
+      (spy-on 'require :and-call-fake
+              (lambda (feature &rest _) (when (eq feature 'remoto-topic) (setq loaded t))))
+      (let ((featurep-orig (symbol-function 'featurep)))
+        (cl-letf (((symbol-function 'featurep)
+                   (lambda (f &rest r)
+                     (if (eq f 'remoto-topic) nil
+                       (apply featurep-orig f r)))))
+          (remoto--require-topic)
+          (expect loaded :to-be t))))))
+
+(describe "remoto-browse issue dispatch"
+  (it "calls remoto-topic-display for #NUM input"
+    (spy-on 'remoto-topic-display :and-return-value (generate-new-buffer "*test*"))
+    (spy-on 'remoto--require-topic)
+    (remoto-browse "foo/bar#42")
+    (expect 'remoto-topic-display :to-have-been-called-with
+            "42" "/github:foo/bar")
+    (kill-buffer "*test*"))
+
+  (it "opens dired for plain owner/repo"
+    (let ((remoto--default-branch-cache (make-hash-table :test 'equal))
+          (remoto--tree-cache (make-hash-table :test 'equal)))
+      (puthash "torvalds/linux" "master" remoto--default-branch-cache)
+      (spy-on 'remoto--fetch-tree :and-return-value (make-hash-table :test 'equal))
+      (spy-on 'dired)
+      (spy-on 'remoto--tree-entry :and-return-value '((type . "tree")))
+      (remoto-browse "torvalds/linux")
+      (expect 'dired :to-have-been-called)))
+
+  (it "opens dired for owner/repo@ref"
+    (spy-on 'dired)
+    (spy-on 'remoto--tree-entry :and-return-value '((type . "tree")))
+    (remoto-browse "torvalds/linux@v6.5")
+    (expect 'dired :to-have-been-called))
+
+  (it "opens dired for owner/repo/ files mode"
+    (let ((remoto--default-branch-cache (make-hash-table :test 'equal)))
+      (puthash "testowner/testrepo" "main" remoto--default-branch-cache)
+      (spy-on 'dired)
+      (spy-on 'remoto--tree-entry :and-return-value '((type . "tree")))
+      (remoto-browse "testowner/testrepo/")
+      (expect 'dired :to-have-been-called)))
+
+  (it "opens file for owner/repo/path/file.el"
+    (let ((remoto--default-branch-cache (make-hash-table :test 'equal)))
+      (puthash "testowner/testrepo" "main" remoto--default-branch-cache)
+      (spy-on 'find-file)
+      (spy-on 'remoto--tree-entry :and-return-value '((type . "blob")))
+      (remoto-browse "testowner/testrepo/src/main.el")
+      (expect 'find-file :to-have-been-called))))
 
 (describe "remoto--read-repo"
   (it "returns completing-read result directly"
@@ -722,7 +901,37 @@
 
   (it "allows owner/repo@ref as direct input"
     (spy-on 'completing-read :and-return-value "agzam/remoto.el@dont-use-gh")
-    (expect (remoto--read-repo) :to-equal "agzam/remoto.el@dont-use-gh")))
+    (expect (remoto--read-repo) :to-equal "agzam/remoto.el@dont-use-gh"))
+
+  (it "allows owner/repo#NUM as direct input"
+    (spy-on 'completing-read :and-return-value "agzam/remoto.el#42")
+    (expect (remoto--read-repo) :to-equal "agzam/remoto.el#42")))
+
+(describe "remoto--browse-metadata"
+  (it "provides affixation for search mode with repo descriptions"
+    (let ((meta (remoto--browse-metadata "torvalds")))
+      (expect (alist-get 'category (cdr meta)) :to-equal 'remoto-browse)
+      (expect (alist-get 'affixation-function (cdr meta)) :to-be-truthy)))
+
+  (it "affixation shows repo descriptions in search mode"
+    (let* ((meta (remoto--browse-metadata "torvalds"))
+           (affix-fn (alist-get 'affixation-function (cdr meta)))
+           (candidates (list (propertize "torvalds/linux"
+                                         'remoto-repo-desc "Unix-like OS kernel")))
+           (result (funcall affix-fn candidates)))
+      (expect (length result) :to-equal 1)
+      (expect (car (car result)) :to-equal "torvalds/linux")
+      ;; suffix should contain the description
+      (expect (nth 2 (car result)) :to-match "Unix-like OS kernel")))
+
+  (it "provides affixation for issues mode"
+    (let ((meta (remoto--browse-metadata "foo/bar#")))
+      (expect (alist-get 'affixation-function (cdr meta)) :to-be-truthy)
+      (expect (alist-get 'group-function (cdr meta)) :to-be-truthy)))
+
+  (it "provides grouping for branches mode"
+    (let ((meta (remoto--browse-metadata "foo/bar@")))
+      (expect (alist-get 'group-function (cdr meta)) :to-be-truthy))))
 
 ;;; Auth fallback
 
@@ -1446,29 +1655,103 @@ Returns the full path after completion, or INPUT if no completion."
     (expect (remoto--handle-file-exists-p "/github:foobar/zapato#42")
             :to-be t)))
 
+;;; ---- Lightweight directory fetch ----
+
+(describe "remoto--fetch-dir-children-light"
+  (it "fetches top-level directory contents"
+    (spy-on 'remoto--api :and-return-value
+            '(((name . "README.md") (type . "file") (size . 500) (sha . "aaa"))
+              ((name . "src") (type . "dir") (size . 0) (sha . "bbb"))
+              ((name . "Makefile") (type . "file") (size . 200) (sha . "ccc"))))
+    (let ((remoto--dir-contents-cache (make-hash-table :test 'equal)))
+      (let ((children (remoto--fetch-dir-children-light "owner" "repo" "main" "")))
+        (expect (length children) :to-equal 3)
+        (expect (assoc "README.md" children) :to-be-truthy)
+        (expect (assoc "src" children) :to-be-truthy)
+        (expect (equal "tree" (alist-get 'type (cdr (assoc "src" children))))
+                :to-be t))))
+
+  (it "caps results at 20 entries"
+    (let ((many-entries (cl-loop for i from 1 to 30
+                                 collect `((name . ,(format "file%d.el" i))
+                                           (type . "file") (size . 100) (sha . "x")))))
+      (spy-on 'remoto--api :and-return-value many-entries)
+      (let ((remoto--dir-contents-cache (make-hash-table :test 'equal)))
+        (let ((children (remoto--fetch-dir-children-light "owner" "repo" "main" "")))
+          (expect (length children) :to-equal 20)))))
+
+  (it "caches results"
+    (let ((remoto--dir-contents-cache (make-hash-table :test 'equal))
+          (call-count 0))
+      (spy-on 'remoto--api :and-call-fake
+              (lambda (_endpoint)
+                (setq call-count (1+ call-count))
+                '(((name . "a.el") (type . "file") (size . 10) (sha . "x")))))
+      (remoto--fetch-dir-children-light "owner" "repo" "main" "")
+      (remoto--fetch-dir-children-light "owner" "repo" "main" "")
+      (expect call-count :to-equal 1)))
+
+  (it "returns nil on API error"
+    (spy-on 'remoto--api :and-call-fake
+            (lambda (_) (user-error "not found")))
+    (let ((remoto--dir-contents-cache (make-hash-table :test 'equal)))
+      (expect (remoto--fetch-dir-children-light "owner" "repo" "main" "")
+              :to-be nil)))
+
+  (it "fetches subdirectory contents"
+    (spy-on 'remoto--api :and-return-value
+            '(((name . "main.el") (type . "file") (size . 1000) (sha . "aa"))
+              ((name . "utils.el") (type . "file") (size . 500) (sha . "bb"))))
+    (let ((remoto--dir-contents-cache (make-hash-table :test 'equal)))
+      (let ((children (remoto--fetch-dir-children-light "owner" "repo" "main" "src")))
+        (expect (length children) :to-equal 2)
+        (expect (assoc "main.el" children) :to-be-truthy)))))
+
 ;;; ---- Completion: files-default level ----
 
 (describe "completion at files-default level"
   (it "lists root files for /github:owner/repo/"
     (remoto-test-with-cache
       (spy-on 'remoto--default-branch :and-return-value "main")
+      (spy-on 'remoto--fetch-dir-children-light :and-return-value
+              '(("README.md" (type . "blob") (size . 500))
+                ("src" (type . "tree") (size . 0))
+                ("bin" (type . "tree") (size . 0))))
       (let ((completions (remoto--handle-file-name-all-completions
                           "" "/github:testowner/testrepo/")))
         (expect (member "README.md" completions) :to-be-truthy)
         (expect (member "src/" completions) :to-be-truthy)
         (expect (member "bin/" completions) :to-be-truthy))))
 
-  (it "filters root files by prefix"
+  (it "filters root files by substring match"
     (remoto-test-with-cache
       (spy-on 'remoto--default-branch :and-return-value "main")
+      (spy-on 'remoto--fetch-dir-children-light :and-return-value
+              '(("README.md" (type . "blob") (size . 500))
+                ("src" (type . "tree") (size . 0))
+                ("bin" (type . "tree") (size . 0))))
       (let ((completions (remoto--handle-file-name-all-completions
-                          "s" "/github:testowner/testrepo/")))
+                          "src" "/github:testowner/testrepo/")))
         (expect (member "src/" completions) :to-be-truthy)
         (expect (member "README.md" completions) :not :to-be-truthy))))
+
+  (it "uses substring matching, not prefix"
+    (remoto-test-with-cache
+      (spy-on 'remoto--default-branch :and-return-value "main")
+      (spy-on 'remoto--fetch-dir-children-light :and-return-value
+              '(("README.md" (type . "blob") (size . 500))
+                ("CONTRIBUTING.md" (type . "blob") (size . 200))))
+      (let ((completions (remoto--handle-file-name-all-completions
+                          "ME" "/github:testowner/testrepo/")))
+        ;; Both contain "ME"
+        (expect (member "README.md" completions) :to-be-truthy))))
 
   (it "lists subdirectory files"
     (remoto-test-with-cache
       (spy-on 'remoto--default-branch :and-return-value "main")
+      (spy-on 'remoto--fetch-dir-children-light :and-return-value
+              '(("main.el" (type . "blob") (size . 1000))
+                ("utils.el" (type . "blob") (size . 500))))
       (let ((completions (remoto--handle-file-name-all-completions
                           "" "/github:testowner/testrepo/src/")))
         (expect (member "main.el" completions) :to-be-truthy)
@@ -1477,6 +1760,7 @@ Returns the full path after completion, or INPUT if no completion."
   (it "returns empty for nonexistent subdirectory"
     (remoto-test-with-cache
       (spy-on 'remoto--default-branch :and-return-value "main")
+      (spy-on 'remoto--fetch-dir-children-light :and-return-value nil)
       (let ((completions (remoto--handle-file-name-all-completions
                           "" "/github:testowner/testrepo/nope/")))
         (expect completions :to-be nil))))
@@ -1486,7 +1770,16 @@ Returns the full path after completion, or INPUT if no completion."
       (spy-on 'remoto--default-branch :and-return-value nil)
       (let ((completions (remoto--handle-file-name-all-completions
                           "" "/github:testowner/testrepo/")))
-        (expect completions :to-be nil)))))
+        (expect completions :to-be nil))))
+
+  (it "does not call remoto--ensure-tree (no recursive fetch)"
+    (remoto-test-with-cache
+      (spy-on 'remoto--default-branch :and-return-value "main")
+      (spy-on 'remoto--fetch-dir-children-light :and-return-value
+              '(("a.el" (type . "blob") (size . 10))))
+      (spy-on 'remoto--ensure-tree)
+      (remoto--handle-file-name-all-completions "" "/github:testowner/testrepo/")
+      (expect 'remoto--ensure-tree :not :to-have-been-called))))
 
 ;;; ---- Completion: issues level ----
 
@@ -1576,8 +1869,11 @@ Returns the full path after completion, or INPUT if no completion."
       (expect (remoto-test--complete "/github:testowner/")
               :to-equal '("testrepo"))
 
-      ;; Step 3: list files on default branch
+      ;; Step 3: list files on default branch (uses lightweight Contents API)
       (spy-on 'remoto--default-branch :and-return-value "main")
+      (spy-on 'remoto--fetch-dir-children-light :and-return-value
+              '(("README.md" . ((type . "blob") (size . 500)))
+                ("src" . ((type . "tree") (size . 0)))))
       (let ((completions (remoto-test--complete "/github:testowner/testrepo/")))
         (expect (member "README.md" completions) :to-be-truthy)
         (expect (member "src/" completions) :to-be-truthy))))
@@ -2012,7 +2308,14 @@ Returns the full path after completion, or INPUT if no completion."
                 '(((commit (message . "cached msg"))))))
       (remoto--fetch-file-commits "o" "r" "main" "" '("f.el"))
       (remoto--fetch-file-commits "o" "r" "main" "" '("f.el"))
-      (expect call-count :to-equal 1))))
+      (expect call-count :to-equal 1)))
+
+  (it "catches generic errors from API (not just user-error)"
+    (let ((remoto--file-commits-cache (make-hash-table :test 'equal)))
+      (spy-on 'remoto--api :and-call-fake
+              (lambda (_endpoint) (error "Connection refused")))
+      (expect (remoto--fetch-file-commits "o" "r" "main" "" '("f.el"))
+              :to-be nil))))
 
 (provide 'remoto-tests)
 

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -1955,6 +1955,62 @@ Returns the full path after completion, or INPUT if no completion."
     (remoto--fetch-user-orgs "anyone")
     (expect 'remoto--api :to-have-been-called-with "user/orgs?per_page=100")))
 
+;;; ---- File commit annotations ----
+
+(describe "file commit annotations"
+  (it "propertizes file candidates with commit messages"
+    (spy-on 'remoto--api :and-call-fake
+            (lambda (endpoint)
+              (cond
+               ((string-match-p "git/trees" endpoint)
+                '((sha . "abc") (tree . (((path . "README.md") (type . "blob")
+                                          (size . 100) (sha . "aaa") (mode . "100644"))
+                                         ((path . "src") (type . "tree")
+                                          (size . 0) (sha . "bbb") (mode . "040000"))))))
+               ((string-match-p "commits.*path=README" endpoint)
+                '(((commit (message . "Initial commit\n\nBody text")))))
+               ((string-match-p "commits.*path=src" endpoint)
+                '(((commit (message . "Add source directory")))))
+               (t nil))))
+    (let ((remoto--file-commits-cache (make-hash-table :test 'equal))
+          (remoto--tree-cache (make-hash-table :test 'equal))
+          (remoto--default-branch-cache (make-hash-table :test 'equal)))
+      (puthash "testowner/testrepo" "main" remoto--default-branch-cache)
+      (remoto-test--install-mock-tree)
+      (let ((result (remoto--fetch-file-commits "testowner" "testrepo" "main" ""
+                                                '("README.md" "src/"))))
+        (expect (alist-get "README.md" result nil nil #'equal)
+                :to-equal "Initial commit")
+        (expect (alist-get "src/" result nil nil #'equal)
+                :to-equal "Add source directory"))))
+
+  (it "provides file commit metadata for canonical paths"
+    (let* ((meta (remoto--completion-metadata "/github:foo/bar@main:/"))
+           (affix-fn (alist-get 'affixation-function meta))
+           (candidate (propertize "file.el" 'remoto-file-commit "Fix typo")))
+      (expect affix-fn :not :to-be nil)
+      (let ((result (funcall affix-fn (list candidate))))
+        (expect (string-match-p "Fix typo" (nth 2 (car result))) :to-be-truthy))))
+
+  (it "provides file commit metadata for files-default paths"
+    (let* ((meta (remoto--completion-metadata "/github:foo/bar/"))
+           (affix-fn (alist-get 'affixation-function meta))
+           (candidate (propertize "src/" 'remoto-file-commit "Refactor modules")))
+      (expect affix-fn :not :to-be nil)
+      (let ((result (funcall affix-fn (list candidate))))
+        (expect (string-match-p "Refactor modules" (nth 2 (car result))) :to-be-truthy))))
+
+  (it "caches results across calls"
+    (let ((remoto--file-commits-cache (make-hash-table :test 'equal))
+          (call-count 0))
+      (spy-on 'remoto--api :and-call-fake
+              (lambda (_endpoint)
+                (cl-incf call-count)
+                '(((commit (message . "cached msg"))))))
+      (remoto--fetch-file-commits "o" "r" "main" "" '("f.el"))
+      (remoto--fetch-file-commits "o" "r" "main" "" '("f.el"))
+      (expect call-count :to-equal 1))))
+
 (provide 'remoto-tests)
 
 ;; Local Variables:

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -1788,16 +1788,16 @@ Returns the full path after completion, or INPUT if no completion."
   (it "detects #NUM pattern in find-file-noselect advice"
     ;; When /github:owner/repo#42 is passed to find-file-noselect,
     ;; it should NOT try to open as a regular file.
-    ;; Instead it should call remoto-issue-display.
-    (spy-on 'remoto-issue-display)
+    ;; Instead it should call remoto-topic-display.
+    (spy-on 'remoto-topic-display)
     (spy-on 'remoto--maybe-rewrite :and-return-value "/github:foo/bar#42")
     ;; Simulate what the advice does
     (let ((filename "/github:foo/bar#42"))
       (when (string-match (rx "#" (group (+ digit)) eos) filename)
-        (remoto-issue-display
+        (remoto-topic-display
          (match-string 1 filename)
          (substring filename 0 (match-beginning 0)))))
-    (expect 'remoto-issue-display :to-have-been-called)))
+    (expect 'remoto-topic-display :to-have-been-called)))
 
 ;;; ---- Root completion enhancement ----
 
@@ -1839,19 +1839,19 @@ Returns the full path after completion, or INPUT if no completion."
 ;;; ---- find-file-noselect intercepts #NUM paths ----
 
 (describe "find-file-noselect intercepts #NUM paths"
-  (it "routes /github:owner/repo#NUM to remoto-issue-display"
-    (spy-on 'remoto-issue-display :and-return-value (generate-new-buffer "*test*"))
-    (spy-on 'remoto--require-issue)
+  (it "routes /github:owner/repo#NUM to remoto-topic-display"
+    (spy-on 'remoto-topic-display :and-return-value (generate-new-buffer "*test*"))
+    (spy-on 'remoto--require-topic)
     (find-file-noselect "/github:testowner/testrepo#42")
-    (expect 'remoto-issue-display :to-have-been-called-with "42" "/github:testowner/testrepo")
+    (expect 'remoto-topic-display :to-have-been-called-with "42" "/github:testowner/testrepo")
     (kill-buffer "*test*"))
 
   (it "does NOT intercept paths without #NUM (passes to orig)"
-    (spy-on 'remoto-issue-display)
+    (spy-on 'remoto-topic-display)
     (spy-on 'remoto--maybe-rewrite :and-return-value "/github:testowner/testrepo@main:/README.md")
-    ;; This would error in real use but we just check issue-display wasn't called
+    ;; This would error in real use but we just check topic-display wasn't called
     (ignore-errors (find-file-noselect "/github:testowner/testrepo@main:/README.md"))
-    (expect 'remoto-issue-display :not :to-have-been-called)))
+    (expect 'remoto-topic-display :not :to-have-been-called)))
 
 ;;; ---- parse-partial-canonical rejects #NUM paths ----
 
@@ -1886,9 +1886,9 @@ Returns the full path after completion, or INPUT if no completion."
   (it "provides issue/PR titles at issues level"
     (let* ((meta (remoto--completion-metadata "/github:foo/bar#"))
            (affix-fn (alist-get 'affixation-function meta))
-           (candidate (propertize "42" 'remoto-issue-title "Fix bug"
-                                      'remoto-issue-state "open"
-                                      'remoto-issue-pr nil)))
+           (candidate (propertize "42" 'remoto-topic-title "Fix bug"
+                                      'remoto-topic-state "open"
+                                      'remoto-topic-pr nil)))
       (expect affix-fn :not :to-be nil)
       (let ((result (funcall affix-fn (list candidate))))
         (expect (string-match-p "Fix bug" (nth 2 (car result))) :to-be-truthy)

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -1836,6 +1836,125 @@ Returns the full path after completion, or INPUT if no completion."
     (let ((remoto--issues-cache (make-hash-table :test 'equal)))
       (expect (remoto--fetch-issues "foo" "nonexistent") :to-be nil))))
 
+;;; ---- find-file-noselect intercepts #NUM paths ----
+
+(describe "find-file-noselect intercepts #NUM paths"
+  (it "routes /github:owner/repo#NUM to remoto-issue-display"
+    (spy-on 'remoto-issue-display :and-return-value (generate-new-buffer "*test*"))
+    (spy-on 'remoto--require-issue)
+    (find-file-noselect "/github:testowner/testrepo#42")
+    (expect 'remoto-issue-display :to-have-been-called-with "42" "/github:testowner/testrepo")
+    (kill-buffer "*test*"))
+
+  (it "does NOT intercept paths without #NUM (passes to orig)"
+    (spy-on 'remoto-issue-display)
+    (spy-on 'remoto--maybe-rewrite :and-return-value "/github:testowner/testrepo@main:/README.md")
+    ;; This would error in real use but we just check issue-display wasn't called
+    (ignore-errors (find-file-noselect "/github:testowner/testrepo@main:/README.md"))
+    (expect 'remoto-issue-display :not :to-have-been-called)))
+
+;;; ---- parse-partial-canonical rejects #NUM paths ----
+
+(describe "parse-partial-canonical rejects # delimiter"
+  (it "returns nil for /github:owner/repo#123"
+    (expect (remoto--parse-partial-canonical "/github:agzam/spacehammer#193") :to-be nil))
+  (it "still parses /github:owner/repo without #"
+    (expect (remoto--parse-partial-canonical "/github:agzam/spacehammer") :not :to-be nil)))
+
+;;; ---- maybe-rewrite preserves #NUM paths ----
+
+(describe "maybe-rewrite preserves #NUM paths"
+  (it "returns /github:owner/repo#NUM unchanged"
+    (expect (remoto--maybe-rewrite "/github:foo/bar#42")
+            :to-equal "/github:foo/bar#42"))
+  (it "returns /github:owner/repo#999 unchanged"
+    (expect (remoto--maybe-rewrite "/github:foo/bar#999")
+            :to-equal "/github:foo/bar#999")))
+
+;;; ---- Completion annotations (affixation-function) ----
+
+(describe "completion annotations"
+  (it "provides repo descriptions at owner level"
+    (let* ((meta (remoto--completion-metadata "/github:testowner/"))
+           (affix-fn (alist-get 'affixation-function meta))
+           (candidate (propertize "myrepo" 'remoto-repo-desc "A cool repo")))
+      (expect affix-fn :not :to-be nil)
+      (let ((result (funcall affix-fn (list candidate))))
+        ;; Should have non-empty suffix
+        (expect (string-match-p "A cool repo" (nth 2 (car result))) :to-be-truthy))))
+
+  (it "provides issue/PR titles at issues level"
+    (let* ((meta (remoto--completion-metadata "/github:foo/bar#"))
+           (affix-fn (alist-get 'affixation-function meta))
+           (candidate (propertize "42" 'remoto-issue-title "Fix bug"
+                                      'remoto-issue-state "open"
+                                      'remoto-issue-pr nil)))
+      (expect affix-fn :not :to-be nil)
+      (let ((result (funcall affix-fn (list candidate))))
+        (expect (string-match-p "Fix bug" (nth 2 (car result))) :to-be-truthy)
+        (expect (string-match-p "open" (nth 2 (car result))) :to-be-truthy))))
+
+  (it "provides group-function for branches/tags"
+    (let* ((meta (remoto--completion-metadata "/github:foo/bar@"))
+           (group-fn (alist-get 'group-function meta))
+           (branch (propertize "main:" 'remoto-ref-type "branch"))
+           (tag (propertize "v1.0:" 'remoto-ref-type "tag")))
+      (expect group-fn :not :to-be nil)
+      (expect (funcall group-fn branch nil) :to-equal "Branch")
+      (expect (funcall group-fn tag nil) :to-equal "Tag")))
+
+  (it "provides user/org type at root level"
+    (let* ((meta (remoto--completion-metadata "/github:"))
+           (affix-fn (alist-get 'affixation-function meta))
+           (user (propertize "agzam/" 'remoto-acct-type "User"))
+           (org (propertize "myorg/" 'remoto-acct-type "Organization")))
+      (expect affix-fn :not :to-be nil)
+      (let ((result (funcall affix-fn (list user org))))
+        (expect (string-match-p "User" (nth 2 (car result))) :to-be-truthy)
+        (expect (string-match-p "Organization" (nth 2 (cadr result))) :to-be-truthy))))
+
+  (it "uses remoto category to avoid marginalia override"
+    (let* ((directory "/github:testowner/"))
+      ;; When metadata is injected, category should be 'remoto
+      ;; This is tested via read-file-name-internal but we can check
+      ;; that completion-metadata returns our custom metadata
+      (expect (remoto--completion-metadata directory) :not :to-be nil))))
+
+;;; ---- remoto--align-affixations ----
+
+(describe "annotation alignment"
+  (it "pads suffixes to align at same column"
+    (let ((items '(("short" "" "desc1")
+                   ("a-much-longer-name" "" "desc2"))))
+      (let ((result (remoto--align-affixations items)))
+        ;; Both suffixes should start at same position relative to candidate end
+        ;; The short one should have more padding
+        (expect (length (nth 2 (car result)))
+                :to-be-greater-than
+                (length (nth 2 (cadr result))))))))
+
+;;; ---- PR ordering in issue completion ----
+
+(describe "PR ordering in issue completion"
+  (it "sorts PRs before issues"
+    (spy-on 'remoto--fetch-issues
+            :and-return-value '(((number . 10) (title . "Bug") (state . "open"))
+                                ((number . 20) (title . "Feature PR") (state . "open")
+                                 (pull_request (url . "http://...")))
+                                ((number . 5) (title . "Another issue") (state . "open"))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (let ((result (remoto--handle-file-name-all-completions "" "/github:foo/bar#")))
+        ;; First should be the PR (number 20)
+        (expect (car result) :to-equal "20")))))
+
+;;; ---- remoto--fetch-user-orgs uses authenticated endpoint ----
+
+(describe "fetch-user-orgs"
+  (it "calls user/orgs endpoint (authenticated)"
+    (spy-on 'remoto--api :and-return-value '(((login . "org1")) ((login . "org2"))))
+    (remoto--fetch-user-orgs "anyone")
+    (expect 'remoto--api :to-have-been-called-with "user/orgs?per_page=100")))
+
 (provide 'remoto-tests)
 
 ;; Local Variables:


### PR DESCRIPTION
## Summary

- New completion levels: files-default (`/github:o/r/`), issues (`/github:o/r#`), branches+tags (`/github:o/r@`)
- Root level shows authenticated user + org memberships
- Dedicated `remoto-issue.el` for issue/PR display buffers (PR-aware: diff stats, reviews, merge state)
- Completion annotations at every level: repo descriptions, issue/PR titles, branch/tag grouping, user/org type, per-file last commit messages
- Proper alignment via `(space :align-to N)` display property
- Category override to prevent Marginalia from clobbering annotations
- `#NUM` interception in `find-file-noselect` routes to issue display

## Test plan

- 268 buttercup specs, 0 failures
- Tests cover: #NUM interception, parse-partial-canonical rejection, maybe-rewrite preservation, all annotation levels, alignment, PR ordering, org endpoint, file commit caching