### PR TITLE
Async non-blocking completion for user/repo search

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,7 @@
 name: Run Tests
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
-  Testing:
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -10,10 +10,22 @@ jobs:
       - name: Check out
         uses: actions/checkout@main
 
+      - name: Cache nix store
+        uses: actions/cache@v4
+        with:
+          path: /nix
+          key: nix-${{ matrix.emacs-version }}
+
       - name: Install Emacs
         uses: purcell/setup-emacs@master
         with:
           version: ${{ matrix.emacs-version }}
+
+      - name: Cache packages
+        uses: actions/cache@v4
+        with:
+          path: .elpa
+          key: elpa-${{ matrix.emacs-version }}-${{ hashFiles('Makefile') }}
 
       - name: Install dependencies
         run: make deps
@@ -21,8 +33,47 @@ jobs:
       - name: Run unit tests
         run: make test
 
-      - name: Run integration tests
-        run: make test-integration
-
       - name: Check byte-compilation
         run: make check-compile
+
+  integration-tests:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs-version: ['29.4', '30.1']
+    steps:
+      - name: Check out
+        uses: actions/checkout@main
+
+      - name: Cache nix store
+        uses: actions/cache@v4
+        with:
+          path: /nix
+          key: nix-${{ matrix.emacs-version }}
+
+      - name: Install Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs-version }}
+
+      - name: Cache packages
+        uses: actions/cache@v4
+        with:
+          path: .elpa
+          key: elpa-${{ matrix.emacs-version }}-${{ hashFiles('Makefile') }}
+
+      - name: Install dependencies
+        run: make deps
+
+      - name: Configure ghub
+        run: |
+          git config --global github.user remoto
+          git config --global github.host api.github.com
+
+      - name: Run integration tests
+        run: make test-integration
+        env:
+          REMOTO_TEST_TOKEN: ${{ secrets.GH_API_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,13 @@ deps: $(ELPA_DIR)
 
 test: $(ELPA_DIR)
 	$(EMACS_BATCH) --directory . \
+	--eval "(setq buttercup-stack-frame-style 'omit)" \
 	-l test/remoto-tests.el \
 	--funcall buttercup-run
 
 test-integration: $(ELPA_DIR)
 	$(EMACS_BATCH) --directory . \
+	--eval "(setq buttercup-stack-frame-style 'omit)" \
 	-l test/remoto-integration-tests.el \
 	--funcall buttercup-run
 

--- a/changelog.org
+++ b/changelog.org
@@ -11,15 +11,24 @@ Changes to the project, following Keep a Changelog conventions.
 - Repo list cache uses a separate longer TTL (~remoto-repo-cache-ttl~, default 30 min) since repo lists rarely change.
 - ~remoto--prefetch-owner-repos~ now uses truly async HTTP instead of ~while-no-input~ wrapper.
 - Repo search below the minimum character threshold narrows from the recent-repos cache instead of returning nil.
+- ~remoto--search-repos-from-parent~ uses substring matching instead of prefix-only when filtering repo names.
+- ~remoto--json-reader~ scans for ~{~ or ~[~ instead of relying on blank-line header heuristic, fixing compatibility across ghub/Emacs versions.
 
 ** Added
 - ~remoto-debounce-delay~ - configurable idle time (default 0.3s) before firing search requests.
 - ~remoto-min-search-chars~ - configurable minimum characters before searching users/repos (default 3).
 - ~remoto-repo-cache-ttl~ - longer cache TTL for repo lists (default 1800s).
 - ~remoto--api-async~ - async GitHub API calls via ~ghub-get~ with ~:callback~.
-- ~remoto--debounce~ - idle-timer-based debounce with generation counter for stale callback invalidation.
+- ~remoto--debounce~ - key-aware idle timer that prevents completion frameworks from starving the async fetch.
 - ~remoto--refresh-minibuffer-completions~ - framework-agnostic minibuffer refresh after async cache updates.
 - ~remoto--search-cache-get~ now accepts an optional TTL parameter for per-key TTL overrides.
+- Fail-fast for integration tests (stop after first failure, skip remaining).
+- CI: split unit and integration test jobs, nix/elpa caching, ~workflow_dispatch~ trigger, PAT-based authenticated integration tests.
+
+** Fixed
+- ~files-default~ handler catches 404 from non-existent repos instead of crashing vertico.
+- ~remoto--api-async~ auth: pass nil (not ~'none~) to ghub for default token resolution.
+- Suppress ~auth-source-search~ echo messages during async completion.
 
 * [1.4.0] - 2026-05-06
 

--- a/changelog.org
+++ b/changelog.org
@@ -3,6 +3,24 @@
 
 Changes to the project, following Keep a Changelog conventions.
 
+* [1.5.0] - 2026-05-06
+
+** Changed
+- Completion for user/org search, repo search, and browse-repos is now fully non-blocking. HTTP requests are debounced and fired asynchronously via ~ghub~ callbacks; cached results are returned immediately while fresh data loads in the background.
+- Minimum search character threshold raised from 2 to 3 (configurable via ~remoto-min-search-chars~).
+- Repo list cache uses a separate longer TTL (~remoto-repo-cache-ttl~, default 30 min) since repo lists rarely change.
+- ~remoto--prefetch-owner-repos~ now uses truly async HTTP instead of ~while-no-input~ wrapper.
+- Repo search below the minimum character threshold narrows from the recent-repos cache instead of returning nil.
+
+** Added
+- ~remoto-debounce-delay~ - configurable idle time (default 0.3s) before firing search requests.
+- ~remoto-min-search-chars~ - configurable minimum characters before searching users/repos (default 3).
+- ~remoto-repo-cache-ttl~ - longer cache TTL for repo lists (default 1800s).
+- ~remoto--api-async~ - async GitHub API calls via ~ghub-get~ with ~:callback~.
+- ~remoto--debounce~ - idle-timer-based debounce with generation counter for stale callback invalidation.
+- ~remoto--refresh-minibuffer-completions~ - framework-agnostic minibuffer refresh after async cache updates.
+- ~remoto--search-cache-get~ now accepts an optional TTL parameter for per-key TTL overrides.
+
 * [1.4.0] - 2026-05-06
 
 ** Added

--- a/remoto.el
+++ b/remoto.el
@@ -681,36 +681,33 @@ Levels: `root', `owner', `repo' (branches/tags), `files-default', `issues'."
 Handles multiple levels: user search at /github:, repo listing at
 /github:OWNER/, branch/tag at /github:OWNER/REPO@, files at
 /github:OWNER/REPO/, issues at /github:OWNER/REPO#, and file
-listing within a repo.  Network calls are wrapped in
-`while-no-input' so typing interrupts pending API requests
-instead of blocking Emacs."
+listing within a repo.  Search-level calls (user, repo) are
+non-blocking: cached results are returned immediately while async
+fetches populate the cache in the background."
   (if-let* ((partial (remoto--parse-partial-github-path directory)))
       (pcase (plist-get partial :level)
         ('root
          ;; Empty query + authenticated: show user + orgs
-         ;; Non-empty: search users/orgs matching FILE
+         ;; Non-empty: search users/orgs matching FILE (non-blocking)
          (if (string-empty-p file)
              (when-let* ((user remoto--authenticated-user))
                (let* ((orgs (remoto--fetch-user-orgs user))
                       (all (cons (propertize user 'remoto-acct-type "User") orgs)))
                  (mapcar (lambda (u) (concat u "/")) all)))
-           (let ((result (while-no-input (remoto--search-users file))))
-             (when (listp result)
-               (let ((filtered (thread-last result
-                                 (seq-filter (lambda (u) (string-prefix-p file u))))))
-                 ;; Pre-fetch repos for the top match so the cache is
-                 ;; warm by the time the user types "/"
-                 (when-let* ((top (car filtered)))
-                   (remoto--prefetch-owner-repos top))
-                 (mapcar (lambda (u) (concat u "/")) filtered))))))
+           (when-let* ((result (remoto--search-users file)))
+             (let ((filtered (seq-filter (lambda (u) (string-prefix-p file u))
+                                         result)))
+               ;; Pre-fetch repos for the top match so the cache is
+               ;; warm by the time the user types "/"
+               (when-let* ((top (car filtered)))
+                 (remoto--prefetch-owner-repos top))
+               (mapcar (lambda (u) (concat u "/")) filtered)))))
         ('owner
-         ;; Repo completion at /github:OWNER/
-         (let* ((owner (plist-get partial :owner))
-                (result (while-no-input
-                          (if (string-empty-p file)
-                              (remoto--recent-owner-repos owner)
-                            (remoto--search-owner-repos owner file)))))
-           (when (listp result) result)))
+         ;; Repo completion at /github:OWNER/ (non-blocking)
+         (let ((owner (plist-get partial :owner)))
+           (if (string-empty-p file)
+               (remoto--recent-owner-repos owner)
+             (remoto--search-owner-repos owner file))))
         ('repo
          ;; Branch + tag completion at /github:OWNER/REPO@
          (if (string-suffix-p ":" file)
@@ -743,8 +740,10 @@ instead of blocking Emacs."
          ;; recursive tree fetch for fast initial display.
          (let* ((owner (plist-get partial :owner))
                 (repo (plist-get partial :repo))
-                (branch (while-no-input
-                          (remoto--default-branch owner repo))))
+                (branch (condition-case nil
+                            (while-no-input
+                              (remoto--default-branch owner repo))
+                          (user-error nil))))
            (when (and (stringp branch) (not (equal branch t)))
              ;; Extract subpath from directory after owner/repo/
              (let* ((repo-end (string-match
@@ -824,7 +823,7 @@ instead of blocking Emacs."
                          (cond
                           ((and a-pr (not b-pr)) t)
                           ((and (not a-pr) b-pr) nil)
-                          (t (> (string-to-number a) (string-to-number b))))))))))))
+                          (t (< (string-to-number b) (string-to-number a))))))))))))
     ;; Full canonical path - existing behavior
     (when-let* ((parsed (remoto--parse-path directory)))
       (let* ((owner (remoto-path-owner parsed))
@@ -1401,23 +1400,114 @@ Set to 0 to disable caching."
   :type 'integer
   :group 'remoto)
 
-(defun remoto--search-cache-get (key)
+(defcustom remoto-debounce-delay 0.3
+  "Seconds of idle time before firing an async search request.
+Lower values feel more responsive but generate more API calls."
+  :type 'number
+  :group 'remoto)
+
+(defcustom remoto-min-search-chars 3
+  "Minimum characters before searching users or repos.
+Prevents premature API requests while typing short prefixes."
+  :type 'integer
+  :group 'remoto)
+
+(defcustom remoto-repo-cache-ttl 1800
+  "Seconds before repo list cache entries expire.
+Repo lists change infrequently, so a longer TTL (default 30 min)
+avoids repeated fetches during a session."
+  :type 'integer
+  :group 'remoto)
+
+(defvar remoto--debounce-timer nil
+  "Active idle timer for debounced async searches.")
+
+(defvar remoto--debounce-key nil
+  "Key identifying the currently pending debounce.
+When a new debounce request arrives with the same key, the
+existing timer is kept rather than cancelled and rescheduled.
+This prevents completion frameworks (vertico, icomplete) from
+starving the async fetch by re-calling the completion function
+on every `post-command-hook' cycle.")
+
+(defvar remoto--async-generation 0
+  "Monotonic counter for invalidating stale async callbacks.
+Incremented on each new debounce schedule; callbacks whose
+captured generation doesn't match the current value are stale
+and skip UI refresh (but still cache their results).")
+
+(defun remoto--search-cache-get (key &optional ttl)
   "Return cached results for KEY if not expired.
+TTL overrides `remoto-search-cache-ttl' when provided.
 Returns two values via list: (HIT-P RESULTS).  HIT-P is non-nil
 when KEY was found and not expired.  RESULTS may be nil for
 queries that returned zero results."
-  (if-let* ((entry (gethash key remoto--search-cache))
-            (timestamp (car entry))
-            (fresh-p (or (zerop remoto-search-cache-ttl)
-                         (< (- (float-time) timestamp) remoto-search-cache-ttl))))
-      (list t (cdr entry))
-    (when entry (remhash key remoto--search-cache))
-    '(nil nil)))
+  (let ((cache-ttl (or ttl remoto-search-cache-ttl)))
+    (if-let* ((entry (gethash key remoto--search-cache))
+              (timestamp (car entry))
+              (fresh-p (or (zerop cache-ttl)
+                           (< (- (float-time) timestamp) cache-ttl))))
+        (list t (cdr entry))
+      (when entry (remhash key remoto--search-cache))
+      '(nil nil))))
 
 (defun remoto--search-cache-put (key results)
   "Store RESULTS for KEY with current timestamp."
   (puthash key (cons (float-time) results) remoto--search-cache)
   results)
+
+(defun remoto--api-async (endpoint callback)
+  "Call GitHub REST API ENDPOINT asynchronously via ghub.
+CALLBACK receives the parsed JSON response. Errors are silently
+dropped since async callers can't meaningfully handle them in the
+completion context. Auth mirrors `remoto--api': nil lets ghub use
+its default token, `none' skips auth entirely."
+  (let* ((resource (concat "/" endpoint))
+         (auth (if remoto--auth-failed 'none remoto-github-auth)))
+    (condition-case nil
+        (let ((inhibit-message t))
+          (ghub-get resource nil
+                    :auth auth
+                    :reader #'remoto--json-reader
+                    :callback callback
+                    :errorback (lambda (_err _headers _status _req)
+                                 nil)))
+      (error nil))))
+
+(defun remoto--debounce (key fn)
+  "Schedule FN after `remoto-debounce-delay' seconds of idle time.
+KEY identifies this request; if a timer is already pending for
+the same KEY, it is kept as-is (no cancel/reschedule).  A
+different KEY cancels the old timer and schedules a new one."
+  (unless (and remoto--debounce-timer
+               (equal key remoto--debounce-key))
+    (when remoto--debounce-timer
+      (cancel-timer remoto--debounce-timer))
+    (setq remoto--debounce-key key)
+    (cl-incf remoto--async-generation)
+    (let ((gen remoto--async-generation))
+      (setq remoto--debounce-timer
+            (run-with-idle-timer
+             remoto-debounce-delay nil
+             (lambda ()
+               (setq remoto--debounce-timer nil
+                     remoto--debounce-key nil)
+               (when (= gen remoto--async-generation)
+                 (funcall fn))))))))
+
+(defun remoto--refresh-minibuffer-completions ()
+  "Refresh the active minibuffer's completion display.
+Called from async callbacks after updating the cache. Invalidates
+the sorted-completions cache and re-triggers the completion
+framework's display hook (works with vertico, icomplete, default)."
+  (run-at-time
+   0 nil
+   (lambda ()
+     (when-let* ((win (active-minibuffer-window)))
+       (with-selected-window win
+         (when (boundp 'completion-all-sorted-completions)
+           (setq completion-all-sorted-completions nil))
+         (run-hooks 'post-command-hook))))))
 
 (defun remoto--search-query (input)
   "Build a GitHub search query string from INPUT.
@@ -1565,130 +1655,190 @@ Returns propertized login strings with type and description."
 
 
 (defun remoto--search-users (prefix)
-  "Search GitHub users/orgs matching PREFIX, cached with TTL.
-Returns a list of login strings. Requires at least 2 characters.
-Uses client-side narrowing when a parent query is cached."
-  (when (<= 2 (length prefix))
-    (let ((prefix-down (downcase prefix)))
-      ;; Check exact cache hit
-      (pcase-let ((`(,hit ,results) (remoto--search-cache-get
-                                      (concat "\0users:" prefix-down))))
-        (if hit results
-          ;; Try narrowing from a shorter cached query
-          (let ((narrowed
-                 (cl-loop for key being the hash-keys of remoto--users-cache
-                          for entry = (gethash key remoto--users-cache)
-                          when (and entry
-                                    (string-prefix-p key prefix-down)
-                                    (< (length key) (length prefix-down))
-                                    (or (zerop remoto-search-cache-ttl)
-                                        (< (- (float-time) (car entry))
-                                           remoto-search-cache-ttl)))
-                          return (seq-filter
-                                  (lambda (u)
-                                    (string-prefix-p prefix-down (downcase u)))
-                                  (cdr entry)))))
-            (if narrowed
-                (progn
-                  (puthash (concat "\0users:" prefix-down)
-                           (cons (float-time) narrowed)
-                           remoto--search-cache)
-                  narrowed)
-              ;; Fetch from API
-              (condition-case nil
-                  (let* ((endpoint (format "search/users?q=%s&per_page=30"
-                                           (url-hexify-string prefix)))
-                         (items (alist-get 'items (remoto--api endpoint)))
+  "Search GitHub users/orgs matching PREFIX, never blocking.
+Returns cached or locally-narrowed results immediately. On cache
+miss, schedules a debounced async fetch and returns nil; the
+completion UI refreshes when results arrive.
+Requires at least `remoto-min-search-chars' characters."
+  (when-let* (((<= remoto-min-search-chars (length prefix)))
+              (prefix-down (downcase prefix)))
+    ;; Check exact cache hit
+    (pcase-let ((`(,hit ,results) (remoto--search-cache-get
+                                    (concat "\0users:" prefix-down))))
+      (if hit results
+        ;; Try narrowing from a shorter cached query
+        (let ((narrowed
+               (cl-loop for key being the hash-keys of remoto--users-cache
+                        for entry = (gethash key remoto--users-cache)
+                        when (and entry
+                                  (string-prefix-p key prefix-down)
+                                  (< (length key) (length prefix-down))
+                                  (or (zerop remoto-search-cache-ttl)
+                                      (< (- (float-time) (car entry))
+                                         remoto-search-cache-ttl)))
+                        return (seq-filter
+                                (lambda (u)
+                                  (string-prefix-p prefix-down (downcase u)))
+                                (cdr entry)))))
+          (if narrowed
+              (progn
+                (puthash (concat "\0users:" prefix-down)
+                         (cons (float-time) narrowed)
+                         remoto--search-cache)
+                narrowed)
+            ;; Schedule async fetch instead of blocking
+            (remoto--debounce
+             (concat "\0users:" prefix-down)
+             (lambda ()
+               (remoto--api-async
+                (format "search/users?q=%s&per_page=30"
+                        (url-hexify-string prefix))
+                (lambda (data)
+                  (let* ((items (alist-get 'items data))
                          (results (mapcar (lambda (item)
-                                            (propertize
-                                             (alist-get 'login item)
-                                             'remoto-acct-type
-                                             (or (alist-get 'type item) "")))
-                                          items)))
+                                           (propertize
+                                            (alist-get 'login item)
+                                            'remoto-acct-type
+                                            (or (alist-get 'type item) "")))
+                                         items)))
                     (puthash prefix-down (cons (float-time) results)
                              remoto--users-cache)
                     (puthash (concat "\0users:" prefix-down)
                              (cons (float-time) results)
                              remoto--search-cache)
-                    results)
-                (user-error nil)))))))))
+                    (remoto--refresh-minibuffer-completions))))))
+            nil))))))
 
 (defvar remoto--prefetch-timer nil
   "Idle timer for speculative repo pre-fetching.")
 
 (defun remoto--prefetch-owner-repos (owner)
-  "Pre-fetch recent repos for OWNER on idle, warming the cache.
-Cancels any previously scheduled pre-fetch."
+  "Pre-fetch recent repos for OWNER asynchronously.
+Cancels any previously scheduled pre-fetch. Uses the async API
+so it never blocks typing."
   (when remoto--prefetch-timer
     (cancel-timer remoto--prefetch-timer))
-  (setq remoto--prefetch-timer
-        (run-with-idle-timer
-         0.001 nil
-         (lambda ()
-           (setq remoto--prefetch-timer nil)
-           ;; Wrap in while-no-input so typing interrupts the
-           ;; synchronous HTTP call instead of blocking Emacs.
-           (while-no-input
-             (remoto--recent-owner-repos owner))))))
+  (let ((cache-key (format "\0repos-recent:%s" (downcase owner))))
+    (setq remoto--prefetch-timer
+          (run-with-idle-timer
+           0.001 nil
+           (lambda ()
+             (setq remoto--prefetch-timer nil)
+             (let ((q (url-hexify-string (format "user:%s" owner))))
+               (remoto--api-async
+                (format "search/repositories?q=%s&sort=updated&per_page=30" q)
+                (lambda (data)
+                  (let ((repos (mapcar
+                                (lambda (item)
+                                  (propertize (alist-get 'name item)
+                                              'remoto-repo-desc
+                                              (or (alist-get 'description item) "")))
+                                (alist-get 'items data))))
+                    (remoto--search-cache-put cache-key repos))))))))))
 
 (defun remoto--recent-owner-repos (owner)
-  "Fetch recently-updated repos for OWNER, cached with TTL.
-Returns up to 30 repo name strings (propertized with description),
-sorted by last push."
+  "Return cached recent repos for OWNER, scheduling async refresh.
+Uses `remoto-repo-cache-ttl' for longer caching. Returns cached
+results immediately (may be nil on first access); an async fetch
+updates the cache and refreshes the completion UI."
   (let* ((cache-key (format "\0repos-recent:%s" (downcase owner))))
-    (pcase-let ((`(,hit ,results) (remoto--search-cache-get cache-key)))
-      (if hit results
-        (condition-case nil
-            (let* ((q (url-hexify-string (format "user:%s" owner)))
-                   (endpoint (format "search/repositories?q=%s&sort=updated&per_page=30" q))
-                   (items (alist-get 'items (remoto--api endpoint)))
-                   (repos (mapcar (lambda (item)
-                                    (propertize (alist-get 'name item)
-                                                'remoto-repo-desc
-                                                (or (alist-get 'description item) "")))
-                                  items)))
-              (remoto--search-cache-put cache-key repos))
-          (user-error nil))))))
+    (pcase-let ((`(,hit ,results) (remoto--search-cache-get
+                                    cache-key remoto-repo-cache-ttl)))
+      (if hit
+          ;; Cache hit - return immediately, schedule background refresh
+          ;; if cache is older than the short TTL (stale but usable)
+          (let ((entry (gethash cache-key remoto--search-cache)))
+            (when (and entry
+                       (< remoto-search-cache-ttl (- (float-time) (car entry))))
+              (remoto--async-refresh-recent-repos owner cache-key))
+            results)
+        ;; Cache miss - schedule async fetch, return nil
+        (remoto--async-refresh-recent-repos owner cache-key)
+        nil))))
+
+(defun remoto--async-refresh-recent-repos (owner cache-key)
+  "Fire async fetch of OWNER's recent repos, updating CACHE-KEY."
+  (remoto--debounce
+   cache-key
+   (lambda ()
+     (let ((q (url-hexify-string (format "user:%s" owner))))
+       (remoto--api-async
+        (format "search/repositories?q=%s&sort=updated&per_page=30" q)
+        (lambda (data)
+          (let ((repos (mapcar (lambda (item)
+                                 (propertize (alist-get 'name item)
+                                             'remoto-repo-desc
+                                             (or (alist-get 'description item) "")))
+                               (alist-get 'items data))))
+            (remoto--search-cache-put cache-key repos)
+            (remoto--refresh-minibuffer-completions))))))))
 
 (defun remoto--search-owner-repos (owner query)
-  "Search OWNER's repos matching QUERY via GitHub search API.
-Returns repo names. Requires at least 2 characters in QUERY.
-Uses client-side narrowing when a parent query is cached."
-  (when (<= 2 (length query))
+  "Search OWNER's repos matching QUERY, never blocking.
+Returns cached or locally-narrowed results immediately. On cache
+miss, schedules a debounced async fetch and returns nil.
+Requires at least `remoto-min-search-chars' characters in QUERY.
+Also narrows from the recent-repos cache when available."
+  (if (< (length query) remoto-min-search-chars)
+      ;; Below threshold: try narrowing from the recent-repos cache
+      (when-let* ((recent-key (format "\0repos-recent:%s" (downcase owner)))
+                  (entry (gethash recent-key remoto--search-cache))
+                  ((or (zerop remoto-repo-cache-ttl)
+                       (< (- (float-time) (car entry)) remoto-repo-cache-ttl))))
+        (seq-filter (lambda (r) (string-search (downcase query) (downcase r)))
+                    (cdr entry)))
     (let* ((owner-down (downcase owner))
-           (query-down (downcase query))
-           (cache-key (format "\0repos:%s/%s" owner-down query-down)))
-      (pcase-let ((`(,hit ,results) (remoto--search-cache-get cache-key)))
-        (if hit results
-          ;; Try narrowing from a shorter cached query for same owner
-          (let ((narrowed
-                 (cl-loop for len from (1- (length query-down)) downto 2
-                          for prefix = (substring query-down 0 len)
-                          for pk = (format "\0repos:%s/%s" owner-down prefix)
-                          for entry = (gethash pk remoto--search-cache)
-                          when (and entry
-                                    (or (zerop remoto-search-cache-ttl)
-                                        (< (- (float-time) (car entry))
-                                           remoto-search-cache-ttl)))
-                          return (seq-filter
-                                  (lambda (r)
-                                    (string-search query-down (downcase r)))
-                                  (cdr entry)))))
-            (if narrowed
-                (remoto--search-cache-put cache-key narrowed)
-              ;; Fetch from API
-              (condition-case nil
-                  (let* ((q (url-hexify-string
-                            (format "%s in:name user:%s" query owner)))
-                         (endpoint (format "search/repositories?q=%s&per_page=100" q))
-                         (items (alist-get 'items (remoto--api endpoint)))
-                         (repos (mapcar (lambda (item)
-                                          (propertize (alist-get 'name item)
-                                                      'remoto-repo-desc
-                                                      (or (alist-get 'description item) "")))
-                                        items)))
-                    (remoto--search-cache-put cache-key repos))
-                (user-error nil)))))))))
+         (query-down (downcase query))
+         (cache-key (format "\0repos:%s/%s" owner-down query-down)))
+    (pcase-let ((`(,hit ,results) (remoto--search-cache-get cache-key)))
+      (if hit results
+        ;; Try narrowing from a shorter search query cache (reliable)
+        (let ((search-narrowed
+               (cl-loop for len from (1- (length query-down)) downto 1
+                        for prefix = (substring query-down 0 len)
+                        for pk = (format "\0repos:%s/%s" owner-down prefix)
+                        for entry = (gethash pk remoto--search-cache)
+                        when (and entry
+                                  (or (zerop remoto-search-cache-ttl)
+                                      (< (- (float-time) (car entry))
+                                         remoto-search-cache-ttl)))
+                        return (seq-filter
+                                (lambda (r)
+                                  (string-search query-down (downcase r)))
+                                (cdr entry)))))
+          (if search-narrowed
+              ;; Narrowed from a real search result - reliable, cache it
+              (remoto--search-cache-put cache-key search-narrowed)
+            ;; No search cache to narrow from. Show preview from
+            ;; recent-repos (if any) but always schedule the real
+            ;; search since recent-repos is only 30 items.
+            (let ((preview
+                   (when-let* ((recent-key (format "\0repos-recent:%s" owner-down))
+                               (entry (gethash recent-key remoto--search-cache))
+                               ((or (zerop remoto-repo-cache-ttl)
+                                    (< (- (float-time) (car entry))
+                                       remoto-repo-cache-ttl))))
+                     (seq-filter (lambda (r)
+                                   (string-search query-down (downcase r)))
+                                 (cdr entry)))))
+              ;; Always schedule async search for full results
+              (remoto--debounce
+               cache-key
+               (lambda ()
+                 (let ((q (url-hexify-string
+                           (format "%s in:name user:%s" query owner))))
+                   (remoto--api-async
+                    (format "search/repositories?q=%s&per_page=100" q)
+                    (lambda (data)
+                      (let ((repos (mapcar (lambda (item)
+                                            (propertize (alist-get 'name item)
+                                                        'remoto-repo-desc
+                                                        (or (alist-get 'description item) "")))
+                                          (alist-get 'items data))))
+                        (remoto--search-cache-put cache-key repos)
+                        (remoto--refresh-minibuffer-completions)))))))
+              ;; Return preview immediately (may be nil)
+              preview))))))))
 
 (defun remoto--get-authenticated-user ()
   "Return the GitHub login of the authenticated user, or nil.
@@ -1720,32 +1870,39 @@ Returns owner/repo@branch candidates matching the prefix after @."
           (mapcar (lambda (b) (format "%s@%s" repo-part b))))))))
 
 (defun remoto--search-repos-fetch (query)
-  "Fetch or retrieve cached repo search results for QUERY.
-Returns a list of owner/repo strings, or nil."
+  "Return cached repo search results for QUERY, never blocking.
+On cache miss, schedules a debounced async fetch and returns nil.
+Requires at least 3 characters."
   (when (<= 3 (length query))
     (if-let* ((cached (remoto--search-cache-get query))
               ((car cached)))
         (cadr cached)
       (if-let* ((parent (remoto--search-repos-from-parent query)))
           (cdr parent)
-        (condition-case nil
-            (let* ((endpoint (format "search/repositories?q=%s&per_page=30"
-                                     (url-hexify-string
-                                      (remoto--search-query query))))
-                   (items (alist-get 'items (remoto--api endpoint)))
-                   (results (mapcar (lambda (item)
-                                     (propertize (alist-get 'full_name item)
-                                                 'remoto-repo-desc
-                                                 (or (alist-get 'description item) "")))
-                                    items)))
-              (remoto--search-cache-put query results))
-          (user-error nil))))))
+        ;; Schedule async fetch instead of blocking
+        (remoto--debounce
+         (concat "\0browse:" query)
+         (lambda ()
+           (remoto--api-async
+            (format "search/repositories?q=%s&per_page=30"
+                    (url-hexify-string (remoto--search-query query)))
+            (lambda (data)
+              (let ((results (mapcar (lambda (item)
+                                      (propertize (alist-get 'full_name item)
+                                                  'remoto-repo-desc
+                                                  (or (alist-get 'description item) "")))
+                                    (alist-get 'items data))))
+                (remoto--search-cache-put query results)
+                (remoto--refresh-minibuffer-completions))))))
+        nil))))
 
 (defun remoto--search-repos-from-parent (query)
   "Try narrowing a cached parent query to answer QUERY.
 Returns (HIT-P . FILTERED-RESULTS) when a parent cache entry
-exists, nil otherwise."
+exists, nil otherwise.  Uses substring matching on the repo
+part (after the slash) to match GitHub's search behavior."
   (when-let* ((slash-pos (string-search "/" query))
+              (repo-part (substring query (1+ slash-pos)))
               (parent-results
                (cl-loop for key being the hash-keys of remoto--search-cache
                         for entry = (remoto--search-cache-get key)
@@ -1754,7 +1911,10 @@ exists, nil otherwise."
                                   (<= slash-pos (length key))
                                   (< (length key) (length query)))
                         return (cadr entry))))
-    (cons t (seq-filter (lambda (name) (string-prefix-p query name))
+    (cons t (seq-filter (lambda (name)
+                          (and (string-prefix-p (substring query 0 (1+ slash-pos)) name)
+                               (or (string-empty-p repo-part)
+                                   (string-search repo-part name))))
                         parent-results))))
 
 (defun remoto--search-repos (query &optional callback)

--- a/remoto.el
+++ b/remoto.el
@@ -5,7 +5,7 @@
 ;; Author: Ag Ibragimov <agzam.ibragimov@gmail.com>
 ;; Maintainer: Ag Ibragimov <agzam.ibragimov@gmail.com>
 ;; Created: April 24, 2026
-;; Version: 1.3.0
+;; Version: 1.5.0
 ;; Keywords: tools vc
 ;; Homepage: https://github.com/agzam/remoto.el
 ;; Package-Requires: ((emacs "29.1") (ghub "4.0.0"))
@@ -130,19 +130,20 @@ Cleared by `remoto-reset-auth'.")
 
 (defun remoto--json-reader (_status)
   "Parse JSON response with list-type arrays for remoto compatibility.
-Handles both header-present and header-stripped response buffers."
+Finds the JSON body by scanning for the first `{' or `[',
+handling both header-present and header-stripped response buffers
+across different ghub and url.el versions."
   (goto-char (point-min))
-  ;; Skip HTTP headers if present; if no blank line found, the
-  ;; buffer is already just the body (varies by Emacs/url.el version).
-  (re-search-forward "^\r?\n" nil t)
-  (let ((body (buffer-substring-no-properties (point) (point-max))))
-    (unless (string-empty-p body)
-      (json-parse-string
-       (decode-coding-string body 'utf-8)
-       :object-type 'alist
-       :array-type 'list
-       :null-object nil
-       :false-object nil))))
+  (when (re-search-forward "[{[]" nil t)
+    (backward-char 1)
+    (let ((body (buffer-substring-no-properties (point) (point-max))))
+      (unless (string-empty-p body)
+        (json-parse-string
+         (decode-coding-string body 'utf-8)
+         :object-type 'alist
+         :array-type 'list
+         :null-object nil
+         :false-object nil)))))
 
 (defun remoto--ghub-get (resource auth endpoint)
   "Call `ghub-get' on RESOURCE with AUTH, translating errors.

--- a/test/remoto-integration-tests.el
+++ b/test/remoto-integration-tests.el
@@ -18,6 +18,37 @@
 (require 'buttercup)
 (require 'remoto)
 
+;; Use API token from environment when available (CI).
+;; Bypasses ghub's auth-source lookup entirely.
+(if-let* ((tok (getenv "REMOTO_TEST_TOKEN")))
+    (progn
+      (setq remoto-github-auth tok)
+      (message "remoto-itest: token loaded (%d chars, prefix: %s)"
+               (length tok) (substring tok 0 (min 4 (length tok)))))
+  (message "remoto-itest: NO TOKEN - REMOTO_TEST_TOKEN not set"))
+
+;; Stop on first failure - mark remaining specs as pending.
+;; Advise the suite runner to check after each spec.
+(defvar remoto-itest--stop nil)
+
+(advice-add 'buttercup--run-suite :around
+            (lambda (fn suite)
+              (cl-letf* ((orig-run-spec (symbol-function 'buttercup--run-spec))
+                         ((symbol-function 'buttercup--run-spec)
+                          (lambda (spec)
+                            (if remoto-itest--stop
+                                (progn
+                                  (setf (buttercup-spec-status spec) 'pending
+                                        (buttercup-spec-failure-description spec)
+                                        "SKIPPED")
+                                  (funcall buttercup-reporter 'spec-started spec)
+                                  (funcall buttercup-reporter 'spec-done spec))
+                              (funcall orig-run-spec spec)
+                              (when (eq (buttercup-spec-status spec) 'failed)
+                                (setq remoto-itest--stop t))))))
+                (funcall fn suite)))
+            '((name . remoto-itest-fail-fast)))
+
 (defconst remoto-itest-owner "emacs-mirror"
   "Test repo owner.")
 

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -1917,12 +1917,15 @@ Returns the full path after completion, or INPUT if no completion."
 (describe "E2E completion: edge cases"
   ;; Delimiter without repo
   (it "returns nil for /github:foo#"
+    (spy-on 'remoto--search-users :and-return-value nil)
     (expect (remoto-test--complete "/github:foo#") :to-be nil))
 
   (it "returns nil for /github:foo@"
+    (spy-on 'remoto--search-users :and-return-value nil)
     (expect (remoto-test--complete "/github:foo@") :to-be nil))
 
   (it "returns nil for /github:foo#42"
+    (spy-on 'remoto--search-users :and-return-value nil)
     (expect (remoto-test--complete "/github:foo#42") :to-be nil))
 
   ;; Nonexistent resources

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -582,103 +582,86 @@
     (expect (remoto--search-query "torvalds/") :to-equal "user:torvalds")
     (expect (remoto--search-query "torvalds/lin") :to-equal "lin in:name user:torvalds"))
 
-  (it "parses search API response into owner/repo list"
-    (spy-on 'remoto--api :and-return-value
-            '((items . (((full_name . "torvalds/linux"))
-                        ((full_name . "torvalds/subsurface"))))))
+  (it "populates cache via async callback"
+    (spy-on 'remoto--debounce :and-call-fake (lambda (_key fn) (funcall fn)))
+    (spy-on 'remoto--api-async :and-call-fake
+            (lambda (_endpoint callback)
+              (funcall callback '((items . (((full_name . "torvalds/linux"))
+                                            ((full_name . "torvalds/subsurface"))))))))
     (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      ;; First call triggers async, returns nil (cache empty)
+      (remoto--search-repos "torvalds")
+      ;; Cache now populated; second call returns results
       (expect (remoto--search-repos "torvalds")
               :to-equal '("torvalds/linux" "torvalds/subsurface"))))
 
-  (it "caches results for repeated queries"
-    (let ((remoto--search-cache (make-hash-table :test 'equal))
-          (call-count 0))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (_endpoint)
-                (setq call-count (1+ call-count))
-                '((items . (((full_name . "torvalds/linux")))))))
-      (remoto--search-repos "torvalds")
-      (remoto--search-repos "torvalds")
-      (expect call-count :to-equal 1)))
+  (it "returns cached results without scheduling async"
+    (spy-on 'remoto--debounce)
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      (puthash "torvalds" (cons (float-time) '("torvalds/linux"))
+               remoto--search-cache)
+      (expect (remoto--search-repos "torvalds")
+              :to-equal '("torvalds/linux"))
+      (expect 'remoto--debounce :not :to-have-been-called)))
 
   (it "filters cached results when query narrows past a slash"
-    (let ((remoto--search-cache (make-hash-table :test 'equal))
-          (call-count 0))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (_endpoint)
-                (setq call-count (1+ call-count))
-                '((items . (((full_name . "agzam/spacehammer"))
-                            ((full_name . "agzam/dotfiles"))
-                            ((full_name . "agzam/remoto.el")))))))
-      ;; First call hits the API
-      (let ((results (remoto--search-repos "agzam")))
-        (expect (length results) :to-equal 3))
-      ;; Query with slash filters cached results, no new API call
-      (let ((results (remoto--search-repos "agzam/spa")))
-        (expect results :to-equal '("agzam/spacehammer"))
-        (expect call-count :to-equal 1))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      ;; Pre-populate cache
+      (puthash "agzam"
+               (cons (float-time) '("agzam/spacehammer" "agzam/dotfiles" "agzam/remoto.el"))
+               remoto--search-cache)
+      ;; Query with slash filters cached results
+      (expect (remoto--search-repos "agzam/spa")
+              :to-equal '("agzam/spacehammer"))
       ;; Further narrowing still uses cache
-      (let ((results (remoto--search-repos "agzam/spaceh")))
-        (expect results :to-equal '("agzam/spacehammer"))
-        (expect call-count :to-equal 1))
-      ;; No match returns empty list, still no API call
-      (let ((results (remoto--search-repos "agzam/zzz")))
-        (expect results :to-be nil)
-        (expect call-count :to-equal 1))))
+      (expect (remoto--search-repos "agzam/spaceh")
+              :to-equal '("agzam/spacehammer"))
+      ;; No match returns nil
+      (expect (remoto--search-repos "agzam/zzz")
+              :to-be nil)))
 
-  (it "does not filter from short prefix cache without slash"
-    (let ((remoto--search-cache (make-hash-table :test 'equal))
-          (call-count 0))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (_endpoint)
-                (setq call-count (1+ call-count))
-                '((items . (((full_name . "agzam/spacehammer")))))))
-      ;; "agz" hits the API
-      (remoto--search-repos "agz")
-      ;; "agzam" should NOT filter from "agz" cache - different search
-      (remoto--search-repos "agzam")
-      (expect call-count :to-equal 2)))
+  (it "schedules async for non-narrowable cache miss"
+    (spy-on 'remoto--debounce)
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      ;; "agz" has no cache and no parent - schedules async
+      (expect (remoto--search-repos "agz") :to-be nil)
+      (expect 'remoto--debounce :to-have-been-called)))
 
-  (it "returns nil on API errors"
-    (spy-on 'remoto--api :and-call-fake
-            (lambda (_endpoint)
-              (user-error "network error")))
+  (it "returns nil on cache miss (async pending)"
+    (spy-on 'remoto--debounce)
     (let ((remoto--search-cache (make-hash-table :test 'equal)))
       (expect (remoto--search-repos "torvalds") :to-be nil)))
 
   (it "expires cache entries after TTL"
     (let ((remoto--search-cache (make-hash-table :test 'equal))
-          (remoto-search-cache-ttl 1)
-          (call-count 0))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (_endpoint)
-                (setq call-count (1+ call-count))
-                '((items . (((full_name . "torvalds/linux")))))))
-      (remoto--search-repos "torvalds")
-      (expect call-count :to-equal 1)
-      ;; Manually expire the entry by backdating the timestamp
-      (let ((entry (gethash "torvalds" remoto--search-cache)))
-        (setcar entry (- (float-time) 10)))
-      ;; Next call should re-fetch
-      (remoto--search-repos "torvalds")
-      (expect call-count :to-equal 2)))
+          (remoto-search-cache-ttl 1))
+      ;; Populate cache with backdated timestamp
+      (puthash "torvalds" (cons (- (float-time) 10) '("torvalds/linux"))
+               remoto--search-cache)
+      ;; Expired entry should not be returned
+      (spy-on 'remoto--debounce)
+      (expect (remoto--search-repos "torvalds") :to-be nil)))
 
-  (it "caches empty results without re-hitting API"
-    (let ((remoto--search-cache (make-hash-table :test 'equal))
-          (call-count 0))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (_endpoint)
-                (setq call-count (1+ call-count))
-                '((items))))
+  (it "caches empty results without re-scheduling async"
+    (spy-on 'remoto--debounce :and-call-fake (lambda (_key fn) (funcall fn)))
+    (spy-on 'remoto--api-async :and-call-fake
+            (lambda (_endpoint callback)
+              (funcall callback '((items)))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      ;; First call: async populates cache with nil results
       (remoto--search-repos "zzzznotfound")
+      ;; Reset spy to track second call
+      (spy-on 'remoto--debounce)
+      ;; Second call hits cache (empty results)
       (remoto--search-repos "zzzznotfound")
-      (expect call-count :to-equal 1)))
+      (expect 'remoto--debounce :not :to-have-been-called)))
 
   (it "delivers results via callback when provided"
-    (spy-on 'remoto--api :and-return-value
-            '((items . (((full_name . "torvalds/linux"))))))
     (let ((remoto--search-cache (make-hash-table :test 'equal))
           (captured nil))
+      ;; Pre-populate cache so search-repos-fetch returns immediately
+      (puthash "torvalds" (cons (float-time) '("torvalds/linux"))
+               remoto--search-cache)
       (remoto--search-repos "torvalds"
                             (lambda (results) (setq captured results)))
       (expect captured :to-equal '("torvalds/linux"))))
@@ -769,10 +752,13 @@
               :to-be-truthy)))
 
   (it "search results carry repo descriptions"
-    (spy-on 'remoto--api :and-return-value
-            '((items . (((full_name . "torvalds/linux")
-                         (description . "Linux kernel"))))))
     (let ((remoto--search-cache (make-hash-table :test 'equal)))
+      ;; Pre-populate cache with propertized results (as async would)
+      (puthash "torvalds"
+               (cons (float-time)
+                     (list (propertize "torvalds/linux"
+                                       'remoto-repo-desc "Linux kernel")))
+               remoto--search-cache)
       (let ((result (remoto--repo-completion-table "torvalds" nil t)))
         (expect (car result) :to-equal "torvalds/linux")
         (expect (get-text-property 0 'remoto-repo-desc (car result))
@@ -1113,95 +1099,123 @@
 ;;; User search
 
 (describe "remoto--search-users"
-  (it "returns nil for short queries"
-    (expect (remoto--search-users "") :to-be nil)
-    (expect (remoto--search-users "a") :to-be nil))
+  (it "returns nil for queries below min-search-chars"
+    (let ((remoto-min-search-chars 3))
+      (expect (remoto--search-users "") :to-be nil)
+      (expect (remoto--search-users "a") :to-be nil)
+      (expect (remoto--search-users "ab") :to-be nil)))
 
-  (it "fetches users from search API"
-    (spy-on 'remoto--api :and-return-value
-            '((items . (((login . "torvalds"))
-                        ((login . "torgeirhelge"))))))
+  (it "schedules async fetch on cache miss, returns nil"
+    (spy-on 'remoto--debounce)
     (let ((remoto--search-cache (make-hash-table :test 'equal))
-          (remoto--users-cache (make-hash-table :test 'equal)))
+          (remoto--users-cache (make-hash-table :test 'equal))
+          (remoto-min-search-chars 3))
+      (expect (remoto--search-users "tor") :to-be nil)
+      (expect 'remoto--debounce :to-have-been-called)))
+
+  (it "populates cache via async callback"
+    ;; Make debounce execute immediately, mock api-async to invoke callback
+    (spy-on 'remoto--debounce :and-call-fake (lambda (_key fn) (funcall fn)))
+    (spy-on 'remoto--api-async :and-call-fake
+            (lambda (_endpoint callback)
+              (funcall callback '((items . (((login . "torvalds") (type . "User"))
+                                            ((login . "torgeirhelge") (type . "User"))))))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal))
+          (remoto--users-cache (make-hash-table :test 'equal))
+          (remoto-min-search-chars 3))
+      ;; First call: triggers async, returns nil
+      (remoto--search-users "tor")
+      ;; Cache should now be populated by the callback
       (expect (remoto--search-users "tor")
               :to-equal '("torvalds" "torgeirhelge"))))
 
-  (it "caches results and avoids repeat API calls"
+  (it "returns cached results without async call"
+    (spy-on 'remoto--debounce)
     (let ((remoto--search-cache (make-hash-table :test 'equal))
           (remoto--users-cache (make-hash-table :test 'equal))
-          (call-count 0))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (_endpoint)
-                (setq call-count (1+ call-count))
-                '((items . (((login . "torvalds")))))))
-      (remoto--search-users "tor")
-      (remoto--search-users "tor")
-      (expect call-count :to-equal 1)))
+          (remoto-min-search-chars 3))
+      ;; Pre-populate cache
+      (puthash "\0users:tor" (cons (float-time) '("torvalds" "torgeirhelge"))
+               remoto--search-cache)
+      (expect (remoto--search-users "tor")
+              :to-equal '("torvalds" "torgeirhelge"))
+      ;; Should not have scheduled any async fetch
+      (expect 'remoto--debounce :not :to-have-been-called)))
 
-  (it "narrows cached results for longer prefixes"
+  (it "narrows cached results for longer prefixes without API call"
+    (spy-on 'remoto--debounce)
     (let ((remoto--search-cache (make-hash-table :test 'equal))
           (remoto--users-cache (make-hash-table :test 'equal))
-          (call-count 0))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (_endpoint)
-                (setq call-count (1+ call-count))
-                '((items . (((login . "torvalds"))
-                            ((login . "torgeirhelge")))))))
-      (remoto--search-users "tor")
+          (remoto-min-search-chars 3))
+      ;; Seed the users-cache with a shorter query
+      (puthash "tor" (cons (float-time) '("torvalds" "torgeirhelge"))
+               remoto--users-cache)
       (let ((result (remoto--search-users "torv")))
         (expect result :to-equal '("torvalds"))
-        (expect call-count :to-equal 1))))
-
-  (it "returns nil on API errors"
-    (spy-on 'remoto--api :and-call-fake
-            (lambda (_) (user-error "network")))
-    (let ((remoto--search-cache (make-hash-table :test 'equal))
-          (remoto--users-cache (make-hash-table :test 'equal)))
-      (expect (remoto--search-users "tor") :to-be nil))))
+        (expect 'remoto--debounce :not :to-have-been-called)))))
 
 ;;; Owner repo search
 
 (describe "remoto--search-owner-repos"
-  (it "returns nil for short queries"
-    (let ((remoto--search-cache (make-hash-table :test 'equal)))
-      (expect (remoto--search-owner-repos "torvalds" "") :to-be nil)
-      (expect (remoto--search-owner-repos "torvalds" "l") :to-be nil)))
-
-  (it "searches repos via API"
-    (spy-on 'remoto--api :and-return-value
-            '((items . (((name . "linux"))
-                        ((name . "libfdt"))))))
-    (let ((remoto--search-cache (make-hash-table :test 'equal)))
-      (let ((result (remoto--search-owner-repos "torvalds" "lin")))
-        (expect result :to-equal '("linux" "libfdt"))
-        (expect 'remoto--api :to-have-been-called)
-        (let ((call-args (spy-calls-args-for 'remoto--api 0)))
-          (expect (car call-args) :to-match "user%3Atorvalds")
-          (expect (car call-args) :to-match "lin")))))
-
-  (it "caches results"
+  (it "returns nil for empty query"
     (let ((remoto--search-cache (make-hash-table :test 'equal))
-          (call-count 0))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (_endpoint)
-                (setq call-count (1+ call-count))
-                '((items . (((name . "linux")))))))
+          (remoto-min-search-chars 3))
+      (expect (remoto--search-owner-repos "torvalds" "") :to-be nil)))
+
+  (it "narrows from recent-repos cache below min-search-chars"
+    (let ((remoto--search-cache (make-hash-table :test 'equal))
+          (remoto-min-search-chars 3)
+          (remoto-repo-cache-ttl 1800))
+      ;; Seed recent-repos cache
+      (puthash "\0repos-recent:torvalds"
+               (cons (float-time) '("linux" "libfdt" "subsurface"))
+               remoto--search-cache)
+      ;; Short query ("li") narrows from recent cache
+      (expect (remoto--search-owner-repos "torvalds" "li")
+              :to-equal '("linux" "libfdt"))))
+
+  (it "schedules async fetch on cache miss"
+    (spy-on 'remoto--debounce)
+    (let ((remoto--search-cache (make-hash-table :test 'equal))
+          (remoto-min-search-chars 3))
+      (expect (remoto--search-owner-repos "torvalds" "lin") :to-be nil)
+      (expect 'remoto--debounce :to-have-been-called)))
+
+  (it "populates cache via async callback"
+    (spy-on 'remoto--debounce :and-call-fake (lambda (_key fn) (funcall fn)))
+    (spy-on 'remoto--api-async :and-call-fake
+            (lambda (_endpoint callback)
+              (funcall callback '((items . (((name . "linux"))
+                                            ((name . "libfdt"))))))))
+    (let ((remoto--search-cache (make-hash-table :test 'equal))
+          (remoto-min-search-chars 3))
       (remoto--search-owner-repos "torvalds" "lin")
-      (remoto--search-owner-repos "torvalds" "lin")
-      (expect call-count :to-equal 1)))
+      ;; Cache now populated
+      (expect (remoto--search-owner-repos "torvalds" "lin")
+              :to-equal '("linux" "libfdt"))))
+
+  (it "returns cached results without async call"
+    (spy-on 'remoto--debounce)
+    (let ((remoto--search-cache (make-hash-table :test 'equal))
+          (remoto-min-search-chars 3))
+      (puthash "\0repos:torvalds/lin"
+               (cons (float-time) '("linux" "libfdt"))
+               remoto--search-cache)
+      (expect (remoto--search-owner-repos "torvalds" "lin")
+              :to-equal '("linux" "libfdt"))
+      (expect 'remoto--debounce :not :to-have-been-called)))
 
   (it "narrows cached results for longer query"
+    (spy-on 'remoto--debounce)
     (let ((remoto--search-cache (make-hash-table :test 'equal))
-          (call-count 0))
-      (spy-on 'remoto--api :and-call-fake
-              (lambda (_endpoint)
-                (setq call-count (1+ call-count))
-                '((items . (((name . "linux"))
-                            ((name . "libfdt")))))))
-      (remoto--search-owner-repos "torvalds" "li")
+          (remoto-min-search-chars 3))
+      ;; Seed with shorter query
+      (puthash "\0repos:torvalds/li"
+               (cons (float-time) '("linux" "libfdt"))
+               remoto--search-cache)
       (let ((result (remoto--search-owner-repos "torvalds" "lin")))
         (expect result :to-equal '("linux"))
-        (expect call-count :to-equal 1)))))
+        (expect 'remoto--debounce :not :to-have-been-called)))))
 
 (describe "remoto--get-authenticated-user"
   (it "returns login from /user endpoint"
@@ -1994,6 +2008,7 @@ Returns the full path after completion, or INPUT if no completion."
   (it "completes unique issue number"
     (spy-on 'remoto--fetch-issues :and-return-value
             '(((number . 42) (title . "Bug"))))
+    (spy-on 'remoto--fetch-issue :and-return-value nil)
     (let ((remoto--search-cache (make-hash-table :test 'equal)))
       (expect (remoto-test--tab-complete "/github:foo/bar#4")
               :to-equal "/github:foo/bar#42")))
@@ -2316,6 +2331,137 @@ Returns the full path after completion, or INPUT if no completion."
               (lambda (_endpoint) (error "Connection refused")))
       (expect (remoto--fetch-file-commits "o" "r" "main" "" '("f.el"))
               :to-be nil))))
+
+;;; Async completion infrastructure
+
+(describe "remoto--debounce"
+  (it "calls run-with-idle-timer with configured delay"
+    (spy-on 'run-with-idle-timer)
+    (spy-on 'cancel-timer)
+    (let ((remoto-debounce-delay 0.5)
+          (remoto--debounce-timer nil)
+          (remoto--debounce-key nil)
+          (remoto--async-generation 0))
+      (remoto--debounce "key1" #'ignore)
+      (expect 'run-with-idle-timer :to-have-been-called)
+      (let ((args (spy-calls-args-for 'run-with-idle-timer 0)))
+        (expect (nth 0 args) :to-equal 0.5))))
+
+  (it "cancels previous timer when key changes"
+    (let* ((fake-timer (list 'timer))
+           (remoto--debounce-timer fake-timer)
+           (remoto--debounce-key "old-key")
+           (remoto--async-generation 0)
+           (remoto-debounce-delay 0.3))
+      (spy-on 'cancel-timer)
+      (spy-on 'run-with-idle-timer :and-return-value (list 'new-timer))
+      (remoto--debounce "new-key" #'ignore)
+      (expect 'cancel-timer :to-have-been-called-with fake-timer)))
+
+  (it "keeps existing timer when same key is re-submitted"
+    (let* ((fake-timer (list 'timer))
+           (remoto--debounce-timer fake-timer)
+           (remoto--debounce-key "same-key")
+           (remoto--async-generation 5)
+           (remoto-debounce-delay 0.3))
+      (spy-on 'cancel-timer)
+      (spy-on 'run-with-idle-timer)
+      (remoto--debounce "same-key" #'ignore)
+      ;; Should not cancel or reschedule
+      (expect 'cancel-timer :not :to-have-been-called)
+      (expect 'run-with-idle-timer :not :to-have-been-called)
+      ;; Generation should not change
+      (expect remoto--async-generation :to-equal 5)))
+
+  (it "increments async generation on each new key"
+    (let ((remoto--debounce-timer nil)
+          (remoto--debounce-key nil)
+          (remoto--async-generation 5)
+          (remoto-debounce-delay 0.3))
+      (spy-on 'run-with-idle-timer :and-return-value 'fake-timer)
+      (spy-on 'cancel-timer)
+      (remoto--debounce "key1" #'ignore)
+      (expect remoto--async-generation :to-equal 6)
+      ;; Same key - no increment (timer still pending)
+      (remoto--debounce "key1" #'ignore)
+      (expect remoto--async-generation :to-equal 6)
+      ;; Different key - cancels old, increments
+      (remoto--debounce "key2" #'ignore)
+      (expect remoto--async-generation :to-equal 7))))
+
+(describe "remoto--api-async"
+  (it "delegates to ghub-get with :callback"
+    (spy-on 'ghub-get)
+    (let ((remoto--auth-failed nil)
+          (remoto-github-auth nil)
+          (remoto--authenticated-user "testuser"))
+      (remoto--api-async "search/users?q=foo" #'ignore)
+      (expect 'ghub-get :to-have-been-called)))
+
+  (it "uses auth=none when auth has failed"
+    (spy-on 'ghub-get)
+    (let ((remoto--auth-failed t))
+      (remoto--api-async "user" #'ignore)
+      (let ((args (spy-calls-args-for 'ghub-get 0)))
+        (expect (plist-get (cddr args) :auth) :to-equal 'none))))
+
+  (it "passes nil auth for default ghub token when authenticated"
+    (spy-on 'ghub-get)
+    (let ((remoto--auth-failed nil)
+          (remoto-github-auth nil)
+          (remoto--authenticated-user "testuser"))
+      (remoto--api-async "user/orgs" #'ignore)
+      (let ((args (spy-calls-args-for 'ghub-get 0)))
+        ;; nil auth lets ghub use its default token mechanism
+        (expect (plist-get (cddr args) :auth) :to-be nil)))))
+
+(describe "remoto--search-cache-get with custom TTL"
+  (it "respects custom TTL parameter"
+    (let ((remoto--search-cache (make-hash-table :test 'equal))
+          (remoto-search-cache-ttl 300))
+      ;; Entry 10 seconds old
+      (puthash "key" (cons (- (float-time) 10) '("val"))
+               remoto--search-cache)
+      ;; Default TTL (300s) - should be fresh
+      (expect (car (remoto--search-cache-get "key")) :to-be-truthy)
+      ;; Custom short TTL (5s) - should be expired
+      (expect (car (remoto--search-cache-get "key" 5)) :to-be nil))))
+
+(describe "remoto--recent-owner-repos"
+  (it "returns nil on cache miss and schedules async"
+    (spy-on 'remoto--debounce)
+    (let ((remoto--search-cache (make-hash-table :test 'equal))
+          (remoto-repo-cache-ttl 1800))
+      (expect (remoto--recent-owner-repos "torvalds") :to-be nil)
+      (expect 'remoto--debounce :to-have-been-called)))
+
+  (it "returns cached repos immediately"
+    (spy-on 'remoto--debounce)
+    (let ((remoto--search-cache (make-hash-table :test 'equal))
+          (remoto-repo-cache-ttl 1800)
+          (remoto-search-cache-ttl 300))
+      (puthash "\0repos-recent:torvalds"
+               (cons (float-time) '("linux" "uemacs"))
+               remoto--search-cache)
+      (expect (remoto--recent-owner-repos "torvalds")
+              :to-equal '("linux" "uemacs"))
+      ;; Should not schedule async since cache is fresh
+      (expect 'remoto--debounce :not :to-have-been-called)))
+
+  (it "schedules background refresh for stale-but-usable cache"
+    (spy-on 'remoto--debounce)
+    (let ((remoto--search-cache (make-hash-table :test 'equal))
+          (remoto-repo-cache-ttl 1800)
+          (remoto-search-cache-ttl 300))
+      ;; Cache entry older than short TTL but within repo TTL
+      (puthash "\0repos-recent:torvalds"
+               (cons (- (float-time) 600) '("linux" "uemacs"))
+               remoto--search-cache)
+      (let ((result (remoto--recent-owner-repos "torvalds")))
+        ;; Returns stale results immediately
+        (expect result :to-equal '("linux" "uemacs"))
+        ;; But also schedules background refresh
+        (expect 'remoto--debounce :to-have-been-called)))))
 
 (provide 'remoto-tests)
 


### PR DESCRIPTION
Replace synchronous HTTP calls in the completion path with cache-first returns and debounced async fetches via ghub callbacks. The UI never blocks during search - cached or locally-narrowed results display instantly while fresh data loads in the background.

- remoto--api-async: ghub-get with :callback for non-blocking HTTP
- remoto--debounce: key-aware idle timer that prevents completion frameworks from starving the async fetch
- remoto--refresh-minibuffer-completions: framework-agnostic display refresh after async cache updates
- Repo search shows preview from recent-repos cache, then replaces with full search API results
- search-repos-from-parent uses substring matching (contains)
- files-default handler catches 404 from non-existent repos
- New defcustoms: remoto-debounce-delay, remoto-min-search-chars, remoto-repo-cache-ttl