### PR TITLE
Fix auth resolution for fresh Emacs sessions

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -3,6 +3,20 @@
 
 Changes to the project, following Keep a Changelog conventions.
 
+* [1.5.1] - 2026-05-07
+
+** Fixed
+- Auth on fresh Emacs sessions. ghub's token resolution searched ~github.com~ while tokens were stored under ~api.github.com~, causing all API calls to fail with a cryptic JSON parse error. Remoto now searches auth-source directly, trying both hosts with ~^forge~, ~^ghub~, and bare username suffixes, then passes the token as a literal string with an explicit ~:host~.
+- ~remoto--warm-auth~ bypasses ~remoto--api~ timeout entirely - calls ghub directly so GPG passphrase entry can complete naturally (like forge does).
+- ~remoto--ghub-get~ catches ~json-error~ and translates it to a readable ~user-error~ instead of letting it propagate as a raw process filter crash.
+
+** Changed
+- ~remoto-auth-timeout~ default raised from 2 to 10 seconds - 2s was too aggressive for first-time GPG decryption.
+
+** Added
+- ~remoto--find-github-token~ - searches auth-source across host and package-suffix combinations, finding the first available token regardless of how it was stored.
+- ~remoto--effective-auth~ - caches the resolved token so subsequent API calls skip the probe. Cleared by ~remoto-reset-auth~.
+
 * [1.5.0] - 2026-05-06
 
 ** Changed

--- a/remoto-topic.el
+++ b/remoto-topic.el
@@ -1,6 +1,6 @@
 ;;; remoto-topic.el --- Issue and PR display for remoto -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024 Ag Ibragimov
+;; Copyright (C) 2026 Ag Ibragimov
 ;; Author: Ag Ibragimov
 
 ;; This file is NOT part of GNU Emacs.

--- a/remoto.el
+++ b/remoto.el
@@ -1,11 +1,11 @@
 ;;; remoto.el --- Browse GitHub repos without cloning -*- lexical-binding: t; -*-
 ;;
-;; Copyright (C) 2025 Ag Ibragimov
+;; Copyright (C) 2026 Ag Ibragimov
 ;;
 ;; Author: Ag Ibragimov <agzam.ibragimov@gmail.com>
 ;; Maintainer: Ag Ibragimov <agzam.ibragimov@gmail.com>
 ;; Created: April 24, 2026
-;; Version: 1.5.0
+;; Version: 1.5.1
 ;; Keywords: tools vc
 ;; Homepage: https://github.com/agzam/remoto.el
 ;; Package-Requires: ((emacs "29.1") (ghub "4.0.0"))
@@ -108,12 +108,12 @@ See ghub documentation for auth-source setup."
                  (string :tag "Literal token"))
   :group 'remoto)
 
-(defcustom remoto-auth-timeout 2
+(defcustom remoto-auth-timeout 10
   "Seconds to wait for auth-source token lookup before giving up.
 When ghub's token lookup (which may trigger GPG decryption of
 authinfo) exceeds this limit, remoto falls back to unauthenticated
-access and caches the failure for the rest of the session.  Use
-`remoto-reset-auth' to retry after adding a token."
+access for that request.  Use `remoto-reset-auth' to retry after
+adding a token."
   :type 'number
   :group 'remoto)
 
@@ -122,6 +122,11 @@ access and caches the failure for the rest of the session.  Use
 Set on actual auth errors (missing token, 401), NOT on timeouts.
 Causes `remoto--api' to skip token lookup and use unauthenticated
 requests.  Reset with `remoto-reset-auth'.")
+
+(defvar remoto--effective-auth nil
+  "Resolved auth value that actually works, or nil if not yet probed.
+Set by `remoto--warm-auth' after trying `remoto-github-auth' and
+falling back to `forge' if available.  Cleared by `remoto-reset-auth'.")
 
 (defvar remoto--authenticated-user nil
   "Cached GitHub login of the authenticated user, or nil if unknown.
@@ -147,12 +152,17 @@ across different ghub and url.el versions."
 
 (defun remoto--ghub-get (resource auth endpoint)
   "Call `ghub-get' on RESOURCE with AUTH, translating errors.
-ENDPOINT is used in error messages for context."
+ENDPOINT is used in error messages for context.  When AUTH is a
+literal token string, `:host' must be specified explicitly because
+ghub's default host resolution sends to github.com (HTML) instead
+of api.github.com (JSON API)."
   (condition-case err
       (let ((inhibit-message (not ghub-debug)))
-        (ghub-get resource nil
-                  :auth auth
-                  :reader #'remoto--json-reader))
+        (apply #'ghub-get resource nil
+               :auth auth
+               :reader #'remoto--json-reader
+               (when (stringp auth)
+                 (list :host "api.github.com"))))
     (ghub-404
      (user-error "Remoto: not found: %s" endpoint))
     (ghub-403
@@ -160,7 +170,9 @@ ENDPOINT is used in error messages for context."
     (ghub-401
      (user-error "Remoto: authentication failed; configure ghub token in auth-source"))
     (ghub-http-error
-     (user-error "Remoto: API error: %s" (error-message-string err)))))
+     (user-error "Remoto: API error: %s" (error-message-string err)))
+    (json-error
+     (user-error "Remoto: could not parse API response for %s" endpoint))))
 
 (defun remoto--api (endpoint)
   "Call GitHub REST API ENDPOINT via ghub, return parsed JSON.
@@ -170,7 +182,9 @@ token is found in auth-source, retries unauthenticated - public
 repos work without any setup.  Signals `user-error' on HTTP
 failures."
   (let* ((resource (concat "/" endpoint))
-         (auth (if remoto--auth-failed 'none remoto-github-auth)))
+         (auth (cond (remoto--auth-failed 'none)
+                     (remoto--effective-auth remoto--effective-auth)
+                     (t remoto-github-auth))))
     (if (eq auth 'none)
         (remoto--ghub-get resource 'none endpoint)
       (condition-case err
@@ -207,8 +221,9 @@ failures."
   "Clear the auth failure cache, retrying token lookup on next API call.
 Use after adding a GitHub token to auth-source."
   (interactive)
-  (setq remoto--auth-failed nil)
-  (setq remoto--authenticated-user nil)
+  (setq remoto--auth-failed nil
+        remoto--effective-auth nil
+        remoto--authenticated-user nil)
   (message "Remoto: auth cache cleared; will retry token lookup on next request"))
 
 (defun remoto--default-branch (owner repo)
@@ -1464,15 +1479,19 @@ dropped since async callers can't meaningfully handle them in the
 completion context. Auth mirrors `remoto--api': nil lets ghub use
 its default token, `none' skips auth entirely."
   (let* ((resource (concat "/" endpoint))
-         (auth (if remoto--auth-failed 'none remoto-github-auth)))
+         (auth (cond (remoto--auth-failed 'none)
+                     (remoto--effective-auth remoto--effective-auth)
+                     (t remoto-github-auth))))
     (condition-case nil
         (let ((inhibit-message t))
-          (ghub-get resource nil
-                    :auth auth
-                    :reader #'remoto--json-reader
-                    :callback callback
-                    :errorback (lambda (_err _headers _status _req)
-                                 nil)))
+          (apply #'ghub-get resource nil
+                 :auth auth
+                 :reader #'remoto--json-reader
+                 :callback callback
+                 :errorback (lambda (_err _headers _status _req)
+                              nil)
+                 (when (stringp auth)
+                   (list :host "api.github.com"))))
       (error nil))))
 
 (defun remoto--debounce (key fn)
@@ -2304,13 +2323,54 @@ Call ORIG-FN with FILENAME and ARGS after any rewrite."
 
 ;;;; Eager auth warm-up
 
+(defun remoto--find-github-token ()
+  "Search auth-source for a GitHub API token.
+Different ghub versions and user setups store tokens under different
+hosts (api.github.com vs github.com) and package suffixes (^forge,
+^ghub).  Try all known combinations to find a working token."
+  (when-let* ((username (condition-case nil
+                            (ghub--username "github.com" nil)
+                          (error nil))))
+    (let ((hosts '("api.github.com" "github.com"))
+          (packages '("forge" "ghub" nil)))
+      (catch 'found
+        (dolist (host hosts)
+          (dolist (pkg packages)
+            (let* ((user (if pkg (format "%s^%s" username pkg) username))
+                   (results (ignore-errors
+                              (auth-source-search :host host :user user :max 1)))
+                   (secret (plist-get (car results) :secret))
+                   (token (if (functionp secret) (funcall secret) secret)))
+              (when (and token (not (string-empty-p token)))
+                (throw 'found token)))))))))
+
 (defun remoto--warm-auth ()
   "Pre-fetch the authenticated GitHub user in the background.
 Runs on an idle timer so GPG decryption happens before the user
-types anything, avoiding timeout-induced fallback to public-only
-repo listings."
+types anything.  Bypasses ghub's own token resolution (which may
+look up the wrong auth-source host) by searching auth-source
+directly and passing the token string to ghub."
   (unless (or remoto--authenticated-user remoto--auth-failed)
-    (remoto--get-authenticated-user)))
+    (if-let* ((token (or (and (stringp remoto-github-auth) remoto-github-auth)
+                         (remoto--find-github-token))))
+        (condition-case err
+            (when-let* ((data (let ((inhibit-message t))
+                                (ghub-get "/user" nil
+                                          :auth token
+                                          :host "api.github.com"
+                                          :reader #'remoto--json-reader)))
+                        (login (alist-get 'login data)))
+              (setq remoto--authenticated-user login
+                    remoto--effective-auth token)
+              (message "Remoto: authenticated as %s" login))
+          (error
+           (setq remoto--auth-failed t)
+           (message "Remoto: token found but API call failed (%s); \
+using unauthenticated access"
+                    (error-message-string err))))
+      (setq remoto--auth-failed t)
+      (message "Remoto: no GitHub token found; only public repos available. \
+See `remoto-github-auth' or configure ghub auth-source, then M-x remoto-reset-auth"))))
 
 (run-with-idle-timer 2 nil #'remoto--warm-auth)
 

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -994,6 +994,127 @@
       (remoto--ghub-get "/repos/owner/repo" 'none "repos/owner/repo")
       (expect captured-inhibit :to-be nil))))
 
+(describe "remoto--json-reader"
+  (it "parses valid JSON"
+    (with-temp-buffer
+      (insert "{\"login\": \"agzam\"}")
+      (expect (remoto--json-reader nil)
+              :to-equal '((login . "agzam")))))
+
+  (it "returns nil for buffers with no JSON delimiters"
+    (with-temp-buffer
+      (insert "plain text no braces")
+      (expect (remoto--json-reader nil) :to-be nil)))
+
+  (it "signals json-error on malformed JSON"
+    (with-temp-buffer
+      (insert "{broken")
+      (expect (remoto--json-reader nil) :to-throw 'json-error)))
+
+  (it "signals json-error on truncated JSON"
+    (with-temp-buffer
+      (insert "{\"name\": ")
+      (expect (remoto--json-reader nil) :to-throw 'json-error))))
+
+(describe "remoto--ghub-get json-error handling"
+  (it "translates json-parse-error to user-error"
+    (spy-on 'ghub-get :and-call-fake
+            (lambda (_resource &optional _params &rest _args)
+              (signal 'json-parse-error '("unexpected character"))))
+    (expect (remoto--ghub-get "/repos/owner/repo" 'none "repos/owner/repo")
+            :to-throw 'user-error))
+
+  (it "translates json-end-of-file to user-error"
+    (spy-on 'ghub-get :and-call-fake
+            (lambda (_resource &optional _params &rest _args)
+              (signal 'json-end-of-file '("premature end"))))
+    (expect (remoto--ghub-get "/repos/owner/repo" 'none "repos/owner/repo")
+            :to-throw 'user-error)))
+
+(describe "remoto--find-github-token"
+  (it "finds token at api.github.com with ^forge suffix"
+    (spy-on 'ghub--username :and-return-value "testuser")
+    (spy-on 'auth-source-search :and-call-fake
+            (lambda (&rest args)
+              (let ((host (plist-get args :host))
+                    (user (plist-get args :user)))
+                (when (and (equal host "api.github.com")
+                           (equal user "testuser^forge"))
+                  (list (list :secret "ghp_found_token"))))))
+    (expect (remoto--find-github-token) :to-equal "ghp_found_token"))
+
+  (it "returns nil when no token found anywhere"
+    (spy-on 'ghub--username :and-return-value "testuser")
+    (spy-on 'auth-source-search :and-return-value nil)
+    (expect (remoto--find-github-token) :to-be nil))
+
+  (it "returns nil when username cannot be determined"
+    (spy-on 'ghub--username :and-call-fake
+            (lambda (&rest _) (error "Cannot determine username")))
+    (expect (remoto--find-github-token) :to-be nil)))
+
+(describe "remoto--warm-auth"
+  (it "caches authenticated user and token on success"
+    (let ((remoto--authenticated-user nil)
+          (remoto--auth-failed nil)
+          (remoto--effective-auth nil))
+      (spy-on 'remoto--find-github-token :and-return-value "ghp_fake_token")
+      (spy-on 'ghub-get :and-return-value '((login . "agzam")))
+      (spy-on 'message)
+      (remoto--warm-auth)
+      (expect remoto--authenticated-user :to-equal "agzam")
+      (expect remoto--effective-auth :to-equal "ghp_fake_token")
+      (expect remoto--auth-failed :to-be nil)))
+
+  (it "sets auth-failed when no token found"
+    (let ((remoto--authenticated-user nil)
+          (remoto--auth-failed nil)
+          (remoto--effective-auth nil)
+          (remoto-github-auth nil))
+      (spy-on 'remoto--find-github-token :and-return-value nil)
+      (spy-on 'message)
+      (remoto--warm-auth)
+      (expect remoto--auth-failed :to-be-truthy)
+      (expect remoto--authenticated-user :to-be nil)))
+
+  (it "sets auth-failed when API call fails with found token"
+    (let ((remoto--authenticated-user nil)
+          (remoto--auth-failed nil)
+          (remoto--effective-auth nil))
+      (spy-on 'remoto--find-github-token :and-return-value "ghp_bad_token")
+      (spy-on 'ghub-get :and-call-fake
+              (lambda (_resource &optional _params &rest _args)
+                (error "401 Unauthorized")))
+      (spy-on 'message)
+      (remoto--warm-auth)
+      (expect remoto--auth-failed :to-be-truthy)
+      (expect remoto--effective-auth :to-be nil)))
+
+  (it "skips when user already cached"
+    (let ((remoto--authenticated-user "agzam")
+          (remoto--auth-failed nil))
+      (spy-on 'remoto--find-github-token)
+      (remoto--warm-auth)
+      (expect 'remoto--find-github-token :not :to-have-been-called)))
+
+  (it "skips when auth already failed"
+    (let ((remoto--authenticated-user nil)
+          (remoto--auth-failed t))
+      (spy-on 'remoto--find-github-token)
+      (remoto--warm-auth)
+      (expect 'remoto--find-github-token :not :to-have-been-called)))
+
+  (it "uses literal remoto-github-auth string directly"
+    (let ((remoto--authenticated-user nil)
+          (remoto--auth-failed nil)
+          (remoto--effective-auth nil)
+          (remoto-github-auth "ghp_explicit_token"))
+      (spy-on 'remoto--find-github-token)
+      (spy-on 'ghub-get :and-return-value '((login . "agzam")))
+      (remoto--warm-auth)
+      (expect 'remoto--find-github-token :not :to-have-been-called)
+      (expect remoto--effective-auth :to-equal "ghp_explicit_token"))))
+
 ;;; Partial path parsing
 
 (describe "remoto--parse-partial-github-path"


### PR DESCRIPTION
## Summary

- ghub's token lookup searched `github.com` while tokens were stored under `api.github.com`, causing JSON parse errors on every API call on fresh Emacs sessions
- `remoto--find-github-token` searches auth-source directly across both hosts with `^forge`, `^ghub`, and bare username suffixes
- When auth is a literal token string, pass `:host "api.github.com"` explicitly to ghub (it defaults to `github.com`, which returns HTML instead of JSON)
- `remoto--warm-auth` bypasses `remoto--api` timeout and calls ghub directly so GPG passphrase entry can complete naturally (like forge does)
- `remoto--ghub-get` catches `json-error` for a readable `user-error` instead of raw process filter crash
- `remoto-auth-timeout` default raised from 2s to 10s

## Test plan

- [x] 331 unit specs pass (`make test`)
- [x] `remoto--find-github-token` finds token at `api.github.com` with `^forge` suffix
- [x] `remoto--warm-auth` authenticates successfully: `(:user "agzam" :has-token t :auth-failed nil)`
- [x] `remoto--api "user"` returns authenticated user data
- [x] Verified `ghub-get` with `:auth token :host "api.github.com"` returns JSON, without `:host` returns HTML