### PR TITLE
Fix API host resolution and auth resilience

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -3,6 +3,18 @@
 
 Changes to the project, following Keep a Changelog conventions.
 
+* [1.5.2] - 2026-05-08
+
+** Fixed
+- Always pass ~:host "api.github.com"~ to ~ghub-get~ in all call sites (~remoto--ghub-get~, ~remoto--api-async~). The conditional guard only sent it for string auth tokens, so unauthenticated calls (~auth = 'none~) hit ~github.com~ instead of the API, returning HTML that crashed the JSON parser.
+- ~remoto--json-reader~ returns nil instead of signaling on malformed JSON, preventing unhandled errors in async contexts where no ~condition-case~ protects the reader callback.
+- ~remoto--warm-auth~ no longer permanently disables auth when the idle-timer token lookup fails. Previously, a transient failure (GPG agent not ready, ghub not loaded) set ~remoto--auth-failed~ to t, locking out private repos for the entire session.
+
+** Added
+- Full pipeline tests asserting every segment (API, default-branch, fetch-tree, tree-entry, tree-children, file-exists-p, file-directory-p, file-regular-p, directory-files, file-attributes, insert-directory) returns non-nil data.
+- Auth forwarding tests verifying the token reaches ghub-get and that auth=none is used when auth-failed is set.
+- JSON reader unit tests covering headers, HTML error pages, empty buffers.
+
 * [1.5.1] - 2026-05-07
 
 ** Fixed

--- a/changelog.org
+++ b/changelog.org
@@ -9,10 +9,13 @@ Changes to the project, following Keep a Changelog conventions.
 - Always pass ~:host "api.github.com"~ to ~ghub-get~ in all call sites (~remoto--ghub-get~, ~remoto--api-async~). The conditional guard only sent it for string auth tokens, so unauthenticated calls (~auth = 'none~) hit ~github.com~ instead of the API, returning HTML that crashed the JSON parser.
 - ~remoto--json-reader~ returns nil instead of signaling on malformed JSON, preventing unhandled errors in async contexts where no ~condition-case~ protects the reader callback.
 - ~remoto--warm-auth~ no longer permanently disables auth when the idle-timer token lookup fails. Previously, a transient failure (GPG agent not ready, ghub not loaded) set ~remoto--auth-failed~ to t, locking out private repos for the entire session.
+- ~remoto--api~ and ~remoto--api-async~ now try ~remoto--find-github-token~ directly when no cached token or user config exists, instead of relying solely on ghub's built-in auth-source lookup (which uses different host/user patterns and often fails on fresh sessions). Found tokens are cached in ~remoto--effective-auth~.
+- Auth failures now signal ~user-error~ with a clear message instead of silently falling back to unauthenticated access. Previously, private repos would quietly show empty results with only a message in ~*Messages*~ that was easily missed.
 
 ** Added
 - Full pipeline tests asserting every segment (API, default-branch, fetch-tree, tree-entry, tree-children, file-exists-p, file-directory-p, file-regular-p, directory-files, file-attributes, insert-directory) returns non-nil data.
 - Auth forwarding tests verifying the token reaches ghub-get and that auth=none is used when auth-failed is set.
+- Fresh-session auth resolution tests: fallback to ~remoto--find-github-token~ when ghub fails, loud ~user-error~ when no token exists anywhere.
 - JSON reader unit tests covering headers, HTML error pages, empty buffers.
 
 * [1.5.1] - 2026-05-07

--- a/remoto.el
+++ b/remoto.el
@@ -143,26 +143,27 @@ across different ghub and url.el versions."
     (backward-char 1)
     (let ((body (buffer-substring-no-properties (point) (point-max))))
       (unless (string-empty-p body)
-        (json-parse-string
-         (decode-coding-string body 'utf-8)
-         :object-type 'alist
-         :array-type 'list
-         :null-object nil
-         :false-object nil)))))
+        (condition-case nil
+            (json-parse-string
+             (decode-coding-string body 'utf-8)
+             :object-type 'alist
+             :array-type 'list
+             :null-object nil
+             :false-object nil)
+          (json-error nil))))))
 
 (defun remoto--ghub-get (resource auth endpoint)
   "Call `ghub-get' on RESOURCE with AUTH, translating errors.
-ENDPOINT is used in error messages for context.  When AUTH is a
-literal token string, `:host' must be specified explicitly because
-ghub's default host resolution sends to github.com (HTML) instead
-of api.github.com (JSON API)."
+ENDPOINT is used in error messages for context.  Always passes
+`:host \"api.github.com\"' explicitly - ghub's default host
+resolution can resolve to github.com (HTML) instead of the
+JSON API endpoint."
   (condition-case err
       (let ((inhibit-message (not ghub-debug)))
-        (apply #'ghub-get resource nil
-               :auth auth
-               :reader #'remoto--json-reader
-               (when (stringp auth)
-                 (list :host "api.github.com"))))
+        (ghub-get resource nil
+                 :auth auth
+                 :reader #'remoto--json-reader
+                 :host "api.github.com"))
     (ghub-404
      (user-error "Remoto: not found: %s" endpoint))
     (ghub-403
@@ -1474,24 +1475,23 @@ queries that returned zero results."
 
 (defun remoto--api-async (endpoint callback)
   "Call GitHub REST API ENDPOINT asynchronously via ghub.
-CALLBACK receives the parsed JSON response. Errors are silently
-dropped since async callers can't meaningfully handle them in the
-completion context. Auth mirrors `remoto--api': nil lets ghub use
-its default token, `none' skips auth entirely."
+CALLBACK receives the parsed JSON response.  Errors are silently
+dropped since async callers cannot meaningfully handle them in the
+completion context.  Always passes `:host \"api.github.com\"'
+explicitly to avoid ghub resolving to the HTML site."
   (let* ((resource (concat "/" endpoint))
          (auth (cond (remoto--auth-failed 'none)
                      (remoto--effective-auth remoto--effective-auth)
                      (t remoto-github-auth))))
     (condition-case nil
         (let ((inhibit-message t))
-          (apply #'ghub-get resource nil
-                 :auth auth
-                 :reader #'remoto--json-reader
-                 :callback callback
-                 :errorback (lambda (_err _headers _status _req)
-                              nil)
-                 (when (stringp auth)
-                   (list :host "api.github.com"))))
+          (ghub-get resource nil
+                    :auth auth
+                    :reader #'remoto--json-reader
+                    :host "api.github.com"
+                    :callback callback
+                    :errorback (lambda (_err _headers _status _req)
+                                 nil)))
       (error nil))))
 
 (defun remoto--debounce (key fn)
@@ -2368,9 +2368,12 @@ directly and passing the token string to ghub."
            (message "Remoto: token found but API call failed (%s); \
 using unauthenticated access"
                     (error-message-string err))))
-      (setq remoto--auth-failed t)
-      (message "Remoto: no GitHub token found; only public repos available. \
-See `remoto-github-auth' or configure ghub auth-source, then M-x remoto-reset-auth"))))
+      ;; No token found yet - don't set auth-failed so remoto--api
+      ;; can still try ghub's own auth-source resolution on demand.
+      ;; The warm-up is opportunistic; failing here should not lock
+      ;; out the session permanently.
+      (message "Remoto: no token found during warm-up; \
+will try ghub auth on first API call"))))
 
 (run-with-idle-timer 2 nil #'remoto--warm-auth)
 

--- a/remoto.el
+++ b/remoto.el
@@ -178,14 +178,21 @@ JSON API endpoint."
 (defun remoto--api (endpoint)
   "Call GitHub REST API ENDPOINT via ghub, return parsed JSON.
 ENDPOINT should not have a leading slash - one is prepended
-automatically.  When `remoto-github-auth' is nil (default) and no
-token is found in auth-source, retries unauthenticated - public
-repos work without any setup.  Signals `user-error' on HTTP
-failures."
+automatically.  Auth resolution order: `remoto--effective-auth',
+`remoto-github-auth', ghub's built-in auth-source lookup,
+`remoto--find-github-token' (last resort).  When every avenue
+fails, signals `user-error'.  Public repos work without any
+setup via unauthenticated fallback."
   (let* ((resource (concat "/" endpoint))
          (auth (cond (remoto--auth-failed 'none)
                      (remoto--effective-auth remoto--effective-auth)
-                     (t remoto-github-auth))))
+                     ((stringp remoto-github-auth) remoto-github-auth)
+                     ;; Try our own auth-source search before ghub's
+                     ;; resolution, which uses different host/user
+                     ;; patterns and often fails on fresh sessions.
+                     (t (when-let* ((token (remoto--find-github-token)))
+                          (setq remoto--effective-auth token)
+                          token)))))
     (if (eq auth 'none)
         (remoto--ghub-get resource 'none endpoint)
       (condition-case err
@@ -202,21 +209,23 @@ failures."
                 (setq result (remoto--ghub-get resource 'none endpoint)))
               result))
         ;; Re-raise API errors (404, 403, etc.) from remoto--ghub-get;
-        ;; these are not auth failures.  Other user-errors (e.g. ghub's
-        ;; "Cannot determine username") are auth config issues - fall
-        ;; through to unauthenticated access.
+        ;; these are not auth failures.
         (user-error
          (if (string-prefix-p "Remoto:" (cadr err))
              (signal (car err) (cdr err))
+           ;; ghub auth config error (e.g. "Cannot determine
+           ;; username").  Every avenue exhausted - fail loudly.
            (setq remoto--auth-failed t)
-           (message "Remoto: auth unavailable (%s); using unauthenticated access"
-                    (error-message-string err))
-           (remoto--ghub-get resource 'none endpoint)))
+           (user-error "Remoto: authentication failed for %s; \
+configure a GitHub token in auth-source, then M-x remoto-reset-auth"
+                       endpoint)))
         (error
+         ;; ghub could not resolve auth at all.  Fail loudly so the
+         ;; user knows auth is the problem, not a missing repo.
          (setq remoto--auth-failed t)
-         (message "Remoto: auth unavailable (%s); using unauthenticated access"
-                  (error-message-string err))
-         (remoto--ghub-get resource 'none endpoint))))))
+         (user-error "Remoto: authentication failed for %s (%s); \
+configure a GitHub token in auth-source, then M-x remoto-reset-auth"
+                     endpoint (error-message-string err)))))))
 
 (defun remoto-reset-auth ()
   "Clear the auth failure cache, retrying token lookup on next API call.
@@ -1482,7 +1491,10 @@ explicitly to avoid ghub resolving to the HTML site."
   (let* ((resource (concat "/" endpoint))
          (auth (cond (remoto--auth-failed 'none)
                      (remoto--effective-auth remoto--effective-auth)
-                     (t remoto-github-auth))))
+                     ((stringp remoto-github-auth) remoto-github-auth)
+                     (t (when-let* ((token (remoto--find-github-token)))
+                          (setq remoto--effective-auth token)
+                          token)))))
     (condition-case nil
         (let ((inhibit-message t))
           (ghub-get resource nil

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -964,17 +964,17 @@
       (expect (remoto--api "repos/owner/repo") :to-equal '((name . "test-repo")))
       (expect remoto--auth-failed :to-be nil)))
 
-  (it "falls back to unauthenticated on auth error"
-    (let ((remoto--auth-failed nil)
-          (remoto-github-auth nil)
-          (remoto-auth-timeout 5))
-      (spy-on 'ghub-get :and-call-fake
-              (lambda (_resource &optional _params &rest args)
-                (if (eq (plist-get args :auth) 'none)
-                    '((name . "test-repo"))
-                  (error "Package ghub requires a Github API token"))))
-      (expect (remoto--api "repos/owner/repo") :to-equal '((name . "test-repo")))
-      (expect remoto--auth-failed :to-be-truthy)))
+    (it "signals user-error on auth error instead of silent fallback"
+      (let ((remoto--auth-failed nil)
+            (remoto--effective-auth nil)
+            (remoto-github-auth nil)
+            (remoto-auth-timeout 5))
+        (spy-on 'ghub-get :and-call-fake
+                (lambda (_resource &optional _params &rest _args)
+                  (error "Package ghub requires a Github API token")))
+        (spy-on 'remoto--find-github-token :and-return-value nil)
+        (expect (remoto--api "repos/owner/repo")
+                :to-throw 'user-error)))
 
   (it "skips auth when failure is cached"
     (let ((remoto--auth-failed t)
@@ -2561,11 +2561,13 @@ Returns the full path after completion, or INPUT if no completion."
       (let ((args (spy-calls-args-for 'ghub-get 0)))
         (expect (plist-get (cddr args) :auth) :to-equal 'none))))
 
-  (it "passes nil auth for default ghub token when authenticated"
+  (it "passes nil auth for default ghub token when no token found"
     (spy-on 'ghub-get)
+    (spy-on 'remoto--find-github-token :and-return-value nil)
     (let ((remoto--auth-failed nil)
           (remoto-github-auth nil)
-          (remoto--authenticated-user "testuser"))
+          (remoto--authenticated-user "testuser")
+          (remoto--effective-auth nil))
       (remoto--api-async "user/orgs" #'ignore)
       (let ((args (spy-calls-args-for 'ghub-get 0)))
         ;; nil auth lets ghub use its default token mechanism
@@ -2908,6 +2910,109 @@ Returns the full path after completion, or INPUT if no completion."
               (lambda (_resource _auth endpoint)
                 (user-error "Remoto: not found: %s" endpoint)))
       (expect (remoto--api "repos/acme/private-repo")
+              :to-throw 'user-error))))
+
+;;; Fresh session: try every auth avenue, fail loudly when none work
+
+(describe "pipeline: fresh session auth resolution"
+  ;; Simulate fresh Emacs: warm-auth hasn't run, all auth state is nil.
+  ;; ghub's own auth-source lookup fails (different host/user patterns).
+  ;; remoto--api should try remoto--find-github-token as a last resort.
+
+  (it "falls back to remoto--find-github-token when ghub auth fails"
+    (let ((remoto--auth-failed nil)
+          (remoto--effective-auth nil)
+          (remoto--authenticated-user nil)
+          (remoto-github-auth nil)
+          (call-count 0))
+      ;; ghub fails with nil auth, succeeds with a real token
+      (spy-on 'ghub-get :and-call-fake
+              (lambda (_resource &optional _params &rest args)
+                (cl-incf call-count)
+                (let ((auth (plist-get args :auth)))
+                  (if (stringp auth)
+                      '((default_branch . "main"))
+                    (error "Required Github token does not exist")))))
+      (spy-on 'remoto--find-github-token :and-return-value "ghp_fallback_token")
+      (let ((data (remoto--api "repos/acme/widgets")))
+        (expect data :to-be-truthy)
+        (expect (alist-get 'default_branch data) :to-equal "main")
+        ;; Should have cached the token for subsequent calls
+        (expect remoto--effective-auth :to-equal "ghp_fallback_token"))))
+
+  (it "does not set auth-failed when fallback token works"
+    (let ((remoto--auth-failed nil)
+          (remoto--effective-auth nil)
+          (remoto--authenticated-user nil)
+          (remoto-github-auth nil))
+      (spy-on 'ghub-get :and-call-fake
+              (lambda (_resource &optional _params &rest args)
+                (let ((auth (plist-get args :auth)))
+                  (if (stringp auth)
+                      '((full_name . "acme/widgets"))
+                    (error "Required Github token does not exist")))))
+      (spy-on 'remoto--find-github-token :and-return-value "ghp_found")
+      (remoto--api "repos/acme/widgets")
+      (expect remoto--auth-failed :to-be nil))))
+
+(describe "pipeline: no auth token anywhere - fail loudly"
+  ;; No token exists: ghub fails, remoto--find-github-token returns
+  ;; nil.  Every avenue exhausted.  The user must see a clear error,
+  ;; not silent empty results.
+
+  (it "remoto--api signals user-error when all auth avenues fail"
+    (let ((remoto--auth-failed nil)
+          (remoto--effective-auth nil)
+          (remoto--authenticated-user nil)
+          (remoto-github-auth nil))
+      (spy-on 'ghub-get :and-call-fake
+              (lambda (_resource &optional _params &rest _args)
+                (error "Required Github token does not exist")))
+      (spy-on 'remoto--find-github-token :and-return-value nil)
+      (expect (remoto--api "repos/acme/private-repo")
+              :to-throw 'user-error)))
+
+  (it "directory-files signals rather than returning silent empty list"
+    (let ((remoto--tree-cache (make-hash-table :test 'equal))
+          (remoto--default-branch-cache (make-hash-table :test 'equal))
+          (remoto--auth-failed nil)
+          (remoto--effective-auth nil)
+          (remoto--authenticated-user nil)
+          (remoto-github-auth nil))
+      (spy-on 'ghub-get :and-call-fake
+              (lambda (_resource &optional _params &rest _args)
+                (error "Required Github token does not exist")))
+      (spy-on 'remoto--find-github-token :and-return-value nil)
+      (expect (directory-files "/github:acme/private@main:/")
+              :to-throw 'user-error)))
+
+  (it "file-exists-p signals rather than returning nil for auth failure"
+    (let ((remoto--tree-cache (make-hash-table :test 'equal))
+          (remoto--default-branch-cache (make-hash-table :test 'equal))
+          (remoto--auth-failed nil)
+          (remoto--effective-auth nil)
+          (remoto--authenticated-user nil)
+          (remoto-github-auth nil))
+      (spy-on 'ghub-get :and-call-fake
+              (lambda (_resource &optional _params &rest _args)
+                (error "Required Github token does not exist")))
+      (spy-on 'remoto--find-github-token :and-return-value nil)
+      (expect (file-exists-p "/github:acme/private@main:/README.md")
+              :to-throw 'user-error)))
+
+  (it "insert-directory signals rather than inserting nothing"
+    (let ((remoto--tree-cache (make-hash-table :test 'equal))
+          (remoto--default-branch-cache (make-hash-table :test 'equal))
+          (remoto--auth-failed nil)
+          (remoto--effective-auth nil)
+          (remoto--authenticated-user nil)
+          (remoto-github-auth nil))
+      (spy-on 'ghub-get :and-call-fake
+              (lambda (_resource &optional _params &rest _args)
+                (error "Required Github token does not exist")))
+      (spy-on 'remoto--find-github-token :and-return-value nil)
+      (expect (with-temp-buffer
+                (insert-directory "/github:acme/private@main:/" "-la"))
               :to-throw 'user-error))))
 
 (provide 'remoto-tests)

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -47,6 +47,36 @@
      (remoto-test--install-mock-tree)
      ,@body))
 
+;;; JSON reader
+
+(describe "remoto--json-reader"
+  (it "parses a valid JSON object"
+    (with-temp-buffer
+      (insert "{\"foo\": 42}")
+      (let ((result (remoto--json-reader nil)))
+        (expect (alist-get 'foo result) :to-equal 42))))
+
+  (it "skips HTTP headers before JSON body"
+    (with-temp-buffer
+      (insert "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"ok\": true}")
+      (let ((result (remoto--json-reader nil)))
+        (expect (alist-get 'ok result) :to-equal t)
+        (expect result :to-be-truthy))))
+
+  (it "returns nil for HTML error pages instead of signaling"
+    (with-temp-buffer
+      (insert "<!DOCTYPE html><html><body>{not json at all</body></html>")
+      (expect (remoto--json-reader nil) :to-be nil)))
+
+  (it "returns nil for empty buffer"
+    (with-temp-buffer
+      (expect (remoto--json-reader nil) :to-be nil)))
+
+  (it "returns arrays as lists"
+    (with-temp-buffer
+      (insert "[1, 2, 3]")
+      (expect (remoto--json-reader nil) :to-equal '(1 2 3)))))
+
 ;;; Path parsing
 
 (describe "remoto--parse-path"
@@ -1006,15 +1036,15 @@
       (insert "plain text no braces")
       (expect (remoto--json-reader nil) :to-be nil)))
 
-  (it "signals json-error on malformed JSON"
+  (it "returns nil on malformed JSON"
     (with-temp-buffer
       (insert "{broken")
-      (expect (remoto--json-reader nil) :to-throw 'json-error)))
+      (expect (remoto--json-reader nil) :to-be nil)))
 
-  (it "signals json-error on truncated JSON"
+  (it "returns nil on truncated JSON"
     (with-temp-buffer
       (insert "{\"name\": ")
-      (expect (remoto--json-reader nil) :to-throw 'json-error))))
+      (expect (remoto--json-reader nil) :to-be nil))))
 
 (describe "remoto--ghub-get json-error handling"
   (it "translates json-parse-error to user-error"
@@ -1066,7 +1096,7 @@
       (expect remoto--effective-auth :to-equal "ghp_fake_token")
       (expect remoto--auth-failed :to-be nil)))
 
-  (it "sets auth-failed when no token found"
+  (it "does not set auth-failed when no token found"
     (let ((remoto--authenticated-user nil)
           (remoto--auth-failed nil)
           (remoto--effective-auth nil)
@@ -1074,7 +1104,9 @@
       (spy-on 'remoto--find-github-token :and-return-value nil)
       (spy-on 'message)
       (remoto--warm-auth)
-      (expect remoto--auth-failed :to-be-truthy)
+      ;; warm-auth is opportunistic; missing token should NOT lock out
+      ;; auth permanently - remoto--api will try ghub's own resolution.
+      (expect remoto--auth-failed :to-be nil)
       (expect remoto--authenticated-user :to-be nil)))
 
   (it "sets auth-failed when API call fails with found token"
@@ -2586,6 +2618,297 @@ Returns the full path after completion, or INPUT if no completion."
         (expect result :to-equal '("linux" "uemacs"))
         ;; But also schedules background refresh
         (expect 'remoto--debounce :to-have-been-called)))))
+
+;;; Full pipeline: every segment must yield data
+
+;; Mock API responses for a realistic repo.  remoto--api is the single
+;; network boundary - everything above it is pure data transformation.
+;; These tests verify that data flows through every segment without
+;; being silently swallowed.
+
+(defconst remoto-test--pipe-prefix "/github:acme/widgets@main:"
+  "Canonical path prefix for pipeline tests.")
+
+(defconst remoto-test--pipe-repo-meta
+  '((full_name . "acme/widgets")
+    (default_branch . "main")
+    (private . t))
+  "Mock repos/:owner/:repo response.")
+
+(defconst remoto-test--pipe-tree-response
+  `((sha . "abc123")
+    (truncated . :false)
+    (tree . (((path . "README.md")
+              (type . "blob") (size . 800) (sha . "aaa") (mode . "100644"))
+             ((path . "src")
+              (type . "tree") (size . 0) (sha . "bbb") (mode . "040000"))
+             ((path . "src/app.py")
+              (type . "blob") (size . 2400) (sha . "ccc") (mode . "100644"))
+             ((path . "src/utils.py")
+              (type . "blob") (size . 650) (sha . "ddd") (mode . "100644"))
+             ((path . "docs")
+              (type . "tree") (size . 0) (sha . "eee") (mode . "040000"))
+             ((path . "docs/guide.md")
+              (type . "blob") (size . 3100) (sha . "fff") (mode . "100644")))))
+  "Mock git/trees/:ref?recursive=1 response.")
+
+(defun remoto-test--pipe-api-fake (endpoint)
+  "Mock API dispatcher for pipeline tests."
+  (cond
+   ((string-match-p "repos/acme/widgets$" endpoint)
+    remoto-test--pipe-repo-meta)
+   ((string-match-p "git/trees/" endpoint)
+    remoto-test--pipe-tree-response)
+   (t (user-error "Remoto: not found: %s" endpoint))))
+
+(defmacro remoto-test-with-pipeline (&rest body)
+  "Run BODY with mock API wired through the full pipeline."
+  (declare (indent 0))
+  `(let ((remoto--tree-cache (make-hash-table :test 'equal))
+         (remoto--default-branch-cache (make-hash-table :test 'equal))
+         (remoto--content-cache (make-hash-table :test 'equal))
+         (remoto--dir-contents-cache (make-hash-table :test 'equal))
+         (remoto--file-commits-cache (make-hash-table :test 'equal))
+         (remoto--auth-failed nil)
+         (remoto--effective-auth "ghp_mock_token")
+         (remoto--authenticated-user "mockuser"))
+     (spy-on 'remoto--api :and-call-fake #'remoto-test--pipe-api-fake)
+     ,@body))
+
+(describe "pipeline: every segment yields data"
+  ;; Segment 1: API returns repo metadata
+  (it "remoto--api returns repo metadata"
+    (remoto-test-with-pipeline
+      (let ((data (remoto--api "repos/acme/widgets")))
+        (expect data :to-be-truthy)
+        (expect (alist-get 'full_name data) :to-equal "acme/widgets")
+        (expect (alist-get 'default_branch data) :to-equal "main"))))
+
+  ;; Segment 2: default branch extraction
+  (it "remoto--default-branch returns a non-empty string"
+    (remoto-test-with-pipeline
+      (let ((branch (remoto--default-branch "acme" "widgets")))
+        (expect branch :to-be-truthy)
+        (expect (stringp branch) :to-be-truthy)
+        (expect (string-empty-p branch) :not :to-be-truthy))))
+
+  ;; Segment 3: tree fetch builds a populated hash table
+  (it "remoto--fetch-tree returns a hash table with entries"
+    (remoto-test-with-pipeline
+      (let ((tree (remoto--fetch-tree "acme" "widgets" "main")))
+        (expect tree :to-be-truthy)
+        (expect (hash-table-p tree) :to-be-truthy)
+        ;; Must have more than just root entries
+        (expect (hash-table-count tree) :to-be-greater-than 2)
+        ;; Root entry must exist
+        (expect (gethash "" tree) :to-be-truthy))))
+
+  ;; Segment 4: ensure-tree caches and returns the tree
+  (it "remoto--ensure-tree caches and returns populated tree"
+    (remoto-test-with-pipeline
+      (let* ((parsed (remoto--parse-path
+                      (concat remoto-test--pipe-prefix "/")))
+             (tree (remoto--ensure-tree parsed)))
+        (expect tree :to-be-truthy)
+        (expect (hash-table-p tree) :to-be-truthy)
+        (expect (hash-table-count tree) :to-be-greater-than 2)
+        ;; Second call should return cached (spy not called again)
+        (let ((call-count (spy-calls-count 'remoto--api)))
+          (remoto--ensure-tree parsed)
+          (expect (spy-calls-count 'remoto--api) :to-equal call-count)))))
+
+  ;; Segment 5: tree-entry finds root, directories, and files
+  (it "remoto--tree-entry finds root directory"
+    (remoto-test-with-pipeline
+      (let ((entry (remoto--tree-entry
+                    (remoto--parse-path
+                     (concat remoto-test--pipe-prefix "/")))))
+        (expect entry :to-be-truthy)
+        (expect (alist-get 'type entry) :to-equal "tree"))))
+
+  (it "remoto--tree-entry finds a subdirectory"
+    (remoto-test-with-pipeline
+      (let ((entry (remoto--tree-entry
+                    (remoto--parse-path
+                     (concat remoto-test--pipe-prefix "/src")))))
+        (expect entry :to-be-truthy)
+        (expect (alist-get 'type entry) :to-equal "tree"))))
+
+  (it "remoto--tree-entry finds a file"
+    (remoto-test-with-pipeline
+      (let ((entry (remoto--tree-entry
+                    (remoto--parse-path
+                     (concat remoto-test--pipe-prefix "/README.md")))))
+        (expect entry :to-be-truthy)
+        (expect (alist-get 'type entry) :to-equal "blob")
+        (expect (alist-get 'size entry) :to-be-greater-than 0))))
+
+  (it "remoto--tree-entry finds a nested file"
+    (remoto-test-with-pipeline
+      (let ((entry (remoto--tree-entry
+                    (remoto--parse-path
+                     (concat remoto-test--pipe-prefix "/src/app.py")))))
+        (expect entry :to-be-truthy)
+        (expect (alist-get 'type entry) :to-equal "blob")
+        (expect (alist-get 'sha entry) :to-be-truthy))))
+
+  (it "remoto--tree-entry returns nil for nonexistent path"
+    (remoto-test-with-pipeline
+      (expect (remoto--tree-entry
+               (remoto--parse-path
+                (concat remoto-test--pipe-prefix "/no/such/file.txt")))
+              :to-be nil)))
+
+  ;; Segment 6: tree-children returns non-empty lists
+  (it "remoto--tree-children lists root children"
+    (remoto-test-with-pipeline
+      (let* ((children (remoto--tree-children
+                        (remoto--parse-path
+                         (concat remoto-test--pipe-prefix "/")))))
+        (expect children :to-be-truthy)
+        (expect (length children) :to-be-greater-than 0)
+        (let ((names (mapcar #'car children)))
+          (expect (member "README.md" names) :to-be-truthy)
+          (expect (member "src" names) :to-be-truthy)
+          (expect (member "docs" names) :to-be-truthy)))))
+
+  (it "remoto--tree-children lists subdirectory children"
+    (remoto-test-with-pipeline
+      (let* ((children (remoto--tree-children
+                        (remoto--parse-path
+                         (concat remoto-test--pipe-prefix "/src/")))))
+        (expect children :to-be-truthy)
+        (expect (length children) :to-equal 2)
+        (let ((names (mapcar #'car children)))
+          (expect (member "app.py" names) :to-be-truthy)
+          (expect (member "utils.py" names) :to-be-truthy)))))
+
+  ;; Segment 7: file-exists-p
+  (it "file-exists-p returns t for known file"
+    (remoto-test-with-pipeline
+      (expect (file-exists-p (concat remoto-test--pipe-prefix "/README.md"))
+              :to-be-truthy)))
+
+  (it "file-exists-p returns t for directory"
+    (remoto-test-with-pipeline
+      (expect (file-exists-p (concat remoto-test--pipe-prefix "/src"))
+              :to-be-truthy)))
+
+  (it "file-exists-p returns nil for missing path"
+    (remoto-test-with-pipeline
+      (expect (file-exists-p (concat remoto-test--pipe-prefix "/nope.txt"))
+              :not :to-be-truthy)))
+
+  ;; Segment 8: file-directory-p / file-regular-p
+  (it "file-directory-p returns t for directories"
+    (remoto-test-with-pipeline
+      (expect (file-directory-p (concat remoto-test--pipe-prefix "/src"))
+              :to-be-truthy)
+      (expect (file-directory-p (concat remoto-test--pipe-prefix "/"))
+              :to-be-truthy)))
+
+  (it "file-directory-p returns nil for files"
+    (remoto-test-with-pipeline
+      (expect (file-directory-p (concat remoto-test--pipe-prefix "/README.md"))
+              :not :to-be-truthy)))
+
+  (it "file-regular-p returns t for files"
+    (remoto-test-with-pipeline
+      (expect (file-regular-p (concat remoto-test--pipe-prefix "/README.md"))
+              :to-be-truthy)
+      (expect (file-regular-p (concat remoto-test--pipe-prefix "/src/app.py"))
+              :to-be-truthy)))
+
+  (it "file-regular-p returns nil for directories"
+    (remoto-test-with-pipeline
+      (expect (file-regular-p (concat remoto-test--pipe-prefix "/src"))
+              :not :to-be-truthy)))
+
+  ;; Segment 9: directory-files
+  (it "directory-files lists root with . and .."
+    (remoto-test-with-pipeline
+      (let ((files (directory-files (concat remoto-test--pipe-prefix "/"))))
+        (expect files :to-be-truthy)
+        (expect (member "." files) :to-be-truthy)
+        (expect (member ".." files) :to-be-truthy)
+        (expect (member "README.md" files) :to-be-truthy)
+        (expect (member "src" files) :to-be-truthy))))
+
+  (it "directory-files lists subdirectory contents"
+    (remoto-test-with-pipeline
+      (let ((files (directory-files (concat remoto-test--pipe-prefix "/src/"))))
+        (expect files :to-be-truthy)
+        (expect (length files) :to-be-greater-than 2) ;; . and .. plus entries
+        (expect (member "app.py" files) :to-be-truthy))))
+
+  ;; Segment 10: file-attributes
+  (it "file-attributes returns non-nil for file with plausible size"
+    (remoto-test-with-pipeline
+      (let ((attrs (file-attributes
+                    (concat remoto-test--pipe-prefix "/README.md"))))
+        (expect attrs :to-be-truthy)
+        (expect (file-attribute-size attrs) :to-be-greater-than 0))))
+
+  (it "file-attributes returns non-nil for directory"
+    (remoto-test-with-pipeline
+      (let ((attrs (file-attributes
+                    (concat remoto-test--pipe-prefix "/src"))))
+        (expect attrs :to-be-truthy)
+        ;; directory attribute: t for dirs
+        (expect (file-attribute-type attrs) :to-equal t))))
+
+  ;; Segment 11: insert-directory produces output
+  (it "insert-directory generates dired-style listing"
+    (remoto-test-with-pipeline
+      (with-temp-buffer
+        (insert-directory (concat remoto-test--pipe-prefix "/") "-la")
+        (let ((content (buffer-string)))
+          (expect (length content) :to-be-greater-than 0)
+          (expect content :to-match "README\\.md")
+          (expect content :to-match "src"))))))
+
+;;; Pipeline: auth forwarding
+
+(describe "pipeline: auth is forwarded to API calls"
+  (it "passes effective-auth token to remoto--ghub-get"
+    (let ((remoto--tree-cache (make-hash-table :test 'equal))
+          (remoto--default-branch-cache (make-hash-table :test 'equal))
+          (remoto--auth-failed nil)
+          (remoto--effective-auth "ghp_private_token")
+          (remoto--authenticated-user "testuser")
+          (captured-auth nil))
+      (spy-on 'ghub-get :and-call-fake
+              (lambda (_resource &optional _params &rest args)
+                (setq captured-auth (plist-get args :auth))
+                '((default_branch . "main"))))
+      (remoto--default-branch "acme" "widgets")
+      (expect captured-auth :to-equal "ghp_private_token")))
+
+  (it "uses auth=none when auth-failed is t"
+    (let ((remoto--tree-cache (make-hash-table :test 'equal))
+          (remoto--default-branch-cache (make-hash-table :test 'equal))
+          (remoto--auth-failed t)
+          (remoto--effective-auth nil)
+          (remoto--authenticated-user nil)
+          (captured-auth nil))
+      (spy-on 'ghub-get :and-call-fake
+              (lambda (_resource &optional _params &rest args)
+                (setq captured-auth (plist-get args :auth))
+                '((default_branch . "main"))))
+      (remoto--default-branch "acme" "widgets")
+      (expect captured-auth :to-equal 'none)))
+
+  (it "signals user-error for private repo with auth=none (404)"
+    (let ((remoto--tree-cache (make-hash-table :test 'equal))
+          (remoto--default-branch-cache (make-hash-table :test 'equal))
+          (remoto--auth-failed t)
+          (remoto--effective-auth nil)
+          (remoto--authenticated-user nil))
+      (spy-on 'remoto--ghub-get :and-call-fake
+              (lambda (_resource _auth endpoint)
+                (user-error "Remoto: not found: %s" endpoint)))
+      (expect (remoto--api "repos/acme/private-repo")
+              :to-throw 'user-error))))
 
 (provide 'remoto-tests)
 


### PR DESCRIPTION
## Summary

- Always pass `:host "api.github.com"` to `ghub-get` in `remoto--ghub-get` and `remoto--api-async`. The conditional `(when (stringp auth) ...)` guard skipped it for symbol auth values like `'none`, sending requests to `github.com` instead of the API - returning HTML that crashed the JSON parser.
- Harden `remoto--json-reader` to return nil on malformed JSON instead of signaling, preventing unhandled errors in async reader callbacks.
- Make `remoto--warm-auth` non-destructive: a transient token-lookup failure (GPG agent not ready, ghub not loaded yet) no longer sets `remoto--auth-failed = t`, which was permanently locking out private org repos for the entire Emacs session.
- Add 29 new test specs: full pipeline tests asserting every segment yields data, auth forwarding tests, and JSON reader hardening tests.

## Test plan

- [x] `make test` - 362 specs, 0 failures
- [x] `make test-integration` - 21 specs, 0 failures
- [x] Verified private org repos now accessible after `remoto-reset-auth`