### PR TITLE
Fetch full results for branches, tags, and organisations

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -3,6 +3,15 @@
 
 Changes to the project, following Keep a Changelog conventions.
 
+* [1.5.3] - 2026-05-30
+
+** Fixed
+- Branch, tag, and organization completion now return the full result set instead of only the first 100 entries. Large repositories (e.g. NixOS/nixpkgs with >100 branches) previously showed a truncated list because each fetch issued a single ~per_page=100~ request.
+
+** Added
+- ~remoto--paginated-api~ - follows pagination to fetch all pages of a GitHub endpoint, bounded by an optional ~max-pages~ cap (default 10) so very large repositories cannot trigger an unbounded run of synchronous API calls.
+- Unit tests for ~remoto--paginated-api~ covering multi-page accumulation, the page cap, and the query-string separator.
+
 * [1.5.2] - 2026-05-08
 
 ** Fixed

--- a/remoto.el
+++ b/remoto.el
@@ -5,7 +5,7 @@
 ;; Author: Ag Ibragimov <agzam.ibragimov@gmail.com>
 ;; Maintainer: Ag Ibragimov <agzam.ibragimov@gmail.com>
 ;; Created: April 24, 2026
-;; Version: 1.5.1
+;; Version: 1.5.3
 ;; Keywords: tools vc
 ;; Homepage: https://github.com/agzam/remoto.el
 ;; Package-Requires: ((emacs "29.1") (ghub "4.0.0"))
@@ -227,20 +227,18 @@ configure a GitHub token in auth-source, then M-x remoto-reset-auth"
 configure a GitHub token in auth-source, then M-x remoto-reset-auth"
                      endpoint (error-message-string err)))))))
 
-(defun remoto--paginated-api (endpoint per-page)
-  "Wrapper for remoto--api that obtains full results from paginated api."
-  (let
-      ((page 1)
-       (full-data nil)
-       (query-endpoint (concat endpoint (if (cl-search "?" endpoint) "&" "?"))))
-    (while
-	(let*
-	    ((endpoint (format "%sper_page=%d&page=%d" query-endpoint per-page page))
-	     (page-data (remoto--api endpoint)))
-	  (setq page (+ page 1))
-	  (setq full-data (append full-data page-data))
-	  (eq (length page-data) per-page)))
-    full-data))
+(defun remoto--paginated-api (endpoint per-page &optional max-pages)
+  "Fetch all pages of paginated GitHub API ENDPOINT via `remoto--api'.
+Request PER-PAGE items per page, following pages until a short page is
+returned or MAX-PAGES (default 10) is reached.  The cap bounds latency
+and request count on very large repositories."
+  (let ((query-endpoint (concat endpoint (if (cl-search "?" endpoint) "&" "?"))))
+    (cl-loop for page from 1 to (or max-pages 10)
+             for page-data = (remoto--api
+                              (format "%sper_page=%d&page=%d"
+                                      query-endpoint per-page page))
+             append page-data
+             until (< (length page-data) per-page))))
 
 (defun remoto-reset-auth ()
   "Clear the auth failure cache, retrying token lookup on next API call.

--- a/remoto.el
+++ b/remoto.el
@@ -227,6 +227,21 @@ configure a GitHub token in auth-source, then M-x remoto-reset-auth"
 configure a GitHub token in auth-source, then M-x remoto-reset-auth"
                      endpoint (error-message-string err)))))))
 
+(defun remoto--paginated-api (endpoint per-page)
+  "Wrapper for remoto--api that obtains full results from paginated api."
+  (let
+      ((page 1)
+       (full-data nil)
+       (query-endpoint (concat endpoint (if (cl-search "?" endpoint) "&" "?"))))
+    (while
+	(let*
+	    ((endpoint (format "%sper_page=%d&page=%d" query-endpoint per-page page))
+	     (page-data (remoto--api endpoint)))
+	  (setq page (+ page 1))
+	  (setq full-data (append full-data page-data))
+	  (eq (length page-data) per-page)))
+    full-data))
+
 (defun remoto-reset-auth ()
   "Clear the auth failure cache, retrying token lookup on next API call.
 Use after adding a GitHub token to auth-source."
@@ -1563,8 +1578,8 @@ Otherwise searches by repository name."
                  (< (- now (car entry)) remoto-search-cache-ttl)))
         (cdr entry)
       (condition-case nil
-          (let* ((endpoint (format "repos/%s/%s/branches?per_page=100" owner repo))
-                 (data (remoto--api endpoint))
+          (let* ((endpoint (format "repos/%s/%s/branches" owner repo))
+                 (data (remoto--paginated-api endpoint 100))
                  (branches (mapcar (lambda (item) (alist-get 'name item)) data)))
             (puthash key (cons now branches) remoto--branches-cache)
             branches)
@@ -1583,8 +1598,8 @@ Otherwise searches by repository name."
                  (< (- now (car entry)) remoto-search-cache-ttl)))
         (cdr entry)
       (condition-case nil
-          (let* ((endpoint (format "repos/%s/%s/tags?per_page=100" owner repo))
-                 (data (remoto--api endpoint))
+          (let* ((endpoint (format "repos/%s/%s/tags" owner repo))
+                 (data (remoto--paginated-api endpoint 100))
                  (tags (mapcar (lambda (item) (alist-get 'name item)) data)))
             (puthash key (cons now tags) remoto--tags-cache)
             tags)
@@ -1675,7 +1690,7 @@ Cached per `remoto-search-cache-ttl'. Capped at 20 API calls."
 Uses /user/orgs which includes private memberships.
 Returns propertized login strings with type and description."
   (condition-case nil
-      (let ((data (remoto--api "user/orgs?per_page=100")))
+      (let ((data (remoto--paginated-api "user/orgs" 100)))
         (mapcar (lambda (item)
                   (propertize (alist-get 'login item)
                               'remoto-acct-type "Organization"

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -2423,7 +2423,40 @@ Returns the full path after completion, or INPUT if no completion."
   (it "calls user/orgs endpoint (authenticated)"
     (spy-on 'remoto--api :and-return-value '(((login . "org1")) ((login . "org2"))))
     (remoto--fetch-user-orgs "anyone")
-    (expect 'remoto--api :to-have-been-called-with "user/orgs?per_page=100")))
+    (expect 'remoto--api :to-have-been-called-with "user/orgs?per_page=100&page=1")))
+
+;;; ---- remoto--paginated-api ----
+
+(describe "remoto--paginated-api"
+  (it "accumulates results across pages until a short page"
+    (let ((calls nil))
+      (spy-on 'remoto--api :and-call-fake
+              (lambda (endpoint)
+                (push endpoint calls)
+                (pcase (length calls)
+                  (1 (make-list 100 '((n . 1))))
+                  (2 (make-list 100 '((n . 2))))
+                  (_ '(((n . 3)))))))
+      (let ((result (remoto--paginated-api "repos/o/r/branches" 100)))
+        (expect (length result) :to-equal 201)
+        (expect (length calls) :to-equal 3)
+        (expect (car calls) :to-equal "repos/o/r/branches?per_page=100&page=3"))))
+
+  (it "stops after a single short page"
+    (spy-on 'remoto--api :and-return-value '(((n . 1)) ((n . 2))))
+    (remoto--paginated-api "user/orgs" 100)
+    (expect 'remoto--api :to-have-been-called-times 1)
+    (expect 'remoto--api :to-have-been-called-with "user/orgs?per_page=100&page=1"))
+
+  (it "caps total requests at MAX-PAGES on huge result sets"
+    (spy-on 'remoto--api :and-return-value (make-list 100 '((n . 1))))
+    (remoto--paginated-api "repos/o/r/tags" 100 3)
+    (expect 'remoto--api :to-have-been-called-times 3))
+
+  (it "uses & as separator when the endpoint already has a query"
+    (spy-on 'remoto--api :and-return-value nil)
+    (remoto--paginated-api "search/things?q=x" 100)
+    (expect 'remoto--api :to-have-been-called-with "search/things?q=x&per_page=100&page=1")))
 
 ;;; ---- File commit annotations ----
 


### PR DESCRIPTION
Large repositories e.g. NixOS/nixpkgs have more than 100 branches.