### PR TITLE
Add forge-agnostic URL commands and remoto-mode

### DIFF
--- a/remoto.el
+++ b/remoto.el
@@ -30,6 +30,7 @@
 
 (require 'cl-lib)
 (require 'files-x)
+(require 'format-spec)
 (require 'ghub)
 
 ;;;; Path parsing
@@ -1431,38 +1432,195 @@ Accept GitHub URLs, git remote URLs, or owner/repo shorthand."
             (revert-buffer)))
       (user-error "Remoto: not in a remoto buffer"))))
 
-;;;###autoload
-(defun remoto-copy-github-url ()
-  "Copy the GitHub web URL for the current file/line to kill ring."
-  (interactive)
-  (let* ((file (or buffer-file-name
-                   (when (derived-mode-p 'dired-mode)
-                     (dired-get-filename nil t))
-                   dired-directory
+;;;; Forge web URLs
+
+(defvar remoto-forge-url-templates
+  '((github
+     (blob    . "https://github.com/%o/%r/blob/%R/%p%L")
+     (tree    . "https://github.com/%o/%r/tree/%R/%p%L")
+     (blame   . "https://github.com/%o/%r/blame/%R/%p%L")
+     (history . "https://github.com/%o/%r/commits/%R/%p")
+     (raw     . "https://raw.githubusercontent.com/%o/%r/%R/%p")
+     (line    . "#L%s")
+     (region  . "#L%s-L%e")))
+  "Per-forge web-URL templates, keyed by forge symbol.
+
+Each value is an alist of (KIND . TEMPLATE).  KIND is one of `blob',
+`tree', `blame', `history', `raw', plus the line-fragment builders
+`line' and `region'.  Templates are expanded with `format-spec' using:
+
+  %o  repository owner
+  %r  repository name
+  %R  git ref (branch, tag, or commit SHA)
+  %p  path relative to the repository root
+  %L  line fragment built from the `line'/`region' templates
+  %s  start line (in the `line' and `region' templates)
+  %e  end line (in the `region' template)
+
+Supporting another forge (GitLab, Codeberg, ...) is a matter of adding
+an entry here and teaching `remoto--parse-path' the new path prefix.")
+
+(defun remoto--forge-type (path)
+  "Return the forge symbol for remoto PATH, or nil when undetermined.
+Derived from the path prefix, e.g. \"/github:...\" -> `github'."
+  (when (and (stringp path)
+             (string-match (rx bos "/" (group (+ (not (any "/:")))) ":") path))
+    (let ((prefix (match-string 1 path)))
+      (if (member prefix '("github" "gh")) 'github (intern prefix)))))
+
+(defun remoto--forge-url (forge kind owner repo ref path &optional line-start line-end)
+  "Build a FORGE web URL of KIND for OWNER/REPO at REF and PATH.
+KIND is one of `blob', `tree', `blame', `history', `raw'.  LINE-START
+and LINE-END add a line or line-range fragment when KIND's template
+includes one."
+  (let* ((templates (or (alist-get forge remoto-forge-url-templates)
+                        (user-error "Remoto: no URL templates for forge `%s'"
+                                    forge)))
+         (template (or (alist-get kind templates)
+                       (user-error "Remoto: forge `%s' has no `%s' URL"
+                                   forge kind)))
+         (line (cond
+                ((and line-start line-end)
+                 (format-spec (alist-get 'region templates)
+                              `((?s . ,line-start) (?e . ,line-end))))
+                (line-start
+                 (format-spec (alist-get 'line templates)
+                              `((?s . ,line-start))))
+                (t ""))))
+    (format-spec template `((?o . ,owner)
+                            (?r . ,repo)
+                            (?R . ,ref)
+                            (?p . ,path)
+                            (?L . ,line)))))
+
+(defun remoto--resolve-commit-sha (owner repo ref)
+  "Resolve REF in OWNER/REPO to a commit SHA via the forge API.
+Used for permalinks so the link survives the ref moving on."
+  (let* ((data (remoto--api (format "repos/%s/%s/commits/%s" owner repo ref)))
+         (sha (alist-get 'sha data)))
+    (or sha
+        (user-error "Remoto: could not resolve commit SHA for %s/%s@%s"
+                    owner repo ref))))
+
+(defun remoto--buffer-file-context ()
+  "Return a context plist describing the current buffer's remoto target.
+
+Keys: :forge :owner :repo :ref :path :kind :line-start :line-end.
+:kind is `blob' for a file or `tree' for a directory; the line keys are
+nil in Dired and for directories.  Works in file buffers (line/region at
+point) and in Dired (entry at point, falling back to the directory).
+Signals a `user-error' when the current buffer is not a remoto buffer."
+  (let* ((dired (derived-mode-p 'dired-mode))
+         (file (or buffer-file-name
+                   (and dired (dired-get-filename nil t))
+                   (and dired (if (listp dired-directory)
+                                  (car dired-directory)
+                                dired-directory))
                    default-directory))
-         (parsed (remoto--parse-path file)))
+         (parsed (and file (remoto--parse-path file))))
     (unless parsed
       (user-error "Remoto: not in a remoto buffer"))
     (let* ((resolved (remoto--resolve-ref parsed))
-           (owner (remoto-path-owner resolved))
-           (repo (remoto-path-repo resolved))
-           (ref (remoto-path-ref resolved))
-           (path (remoto--relative-path (remoto-path-path resolved)))
            (entry (remoto--tree-entry resolved))
-           (type (if (and entry (equal "tree" (alist-get 'type entry)))
-                     "tree" "blob"))
-           (line-suffix (when (and (equal type "blob")
-                                   (not (derived-mode-p 'dired-mode)))
-                          (if (use-region-p)
-                              (format "#L%d-L%d"
-                                      (line-number-at-pos (region-beginning))
-                                      (line-number-at-pos (region-end)))
-                            (format "#L%d" (line-number-at-pos)))))
-           (url (format "https://github.com/%s/%s/%s/%s/%s%s"
-                        owner repo type ref path
-                        (or line-suffix ""))))
-      (kill-new url)
-      (message "Copied: %s" url))))
+           (kind (if (and entry (equal "tree" (alist-get 'type entry)))
+                     'tree 'blob))
+           (lines (and (eq kind 'blob) (not dired)))
+           (line-start (and lines
+                            (line-number-at-pos
+                             (if (use-region-p) (region-beginning) (point)))))
+           (line-end (and lines (use-region-p)
+                          (line-number-at-pos (region-end)))))
+      (list :forge (remoto--forge-type file)
+            :owner (remoto-path-owner resolved)
+            :repo (remoto-path-repo resolved)
+            :ref (remoto-path-ref resolved)
+            :path (remoto--relative-path (remoto-path-path resolved))
+            :kind kind
+            :line-start line-start
+            :line-end line-end))))
+
+(defun remoto--context-url (ctx kind &optional ref)
+  "Build a URL of KIND from context plist CTX.
+Optional REF overrides the ref in CTX (used for permalinks)."
+  (remoto--forge-url (plist-get ctx :forge)
+                     kind
+                     (plist-get ctx :owner)
+                     (plist-get ctx :repo)
+                     (or ref (plist-get ctx :ref))
+                     (plist-get ctx :path)
+                     (plist-get ctx :line-start)
+                     (plist-get ctx :line-end)))
+
+(defun remoto--require-blob (ctx what)
+  "Signal a `user-error' unless CTX refers to a file.
+WHAT names the operation, for the error message."
+  (unless (eq (plist-get ctx :kind) 'blob)
+    (user-error "Remoto: %s is only available for files, not directories"
+                what)))
+
+(defun remoto--kill-url (url)
+  "Put URL on the kill ring and report it in the echo area."
+  (kill-new url)
+  (message "Copied: %s" url))
+
+;;;; URL commands
+
+;;;###autoload
+(defun remoto-copy-url ()
+  "Copy the forge web URL for the current file or directory.
+In a file buffer the link targets the current line, or the active
+region as a line range.  In Dired it targets the entry at point, or
+the directory itself."
+  (interactive)
+  (let ((ctx (remoto--buffer-file-context)))
+    (remoto--kill-url (remoto--context-url ctx (plist-get ctx :kind)))))
+
+;;;###autoload
+(defun remoto-copy-blame-url ()
+  "Copy the forge blame URL for the current file and line/region."
+  (interactive)
+  (let ((ctx (remoto--buffer-file-context)))
+    (remoto--require-blob ctx "Blame")
+    (remoto--kill-url (remoto--context-url ctx 'blame))))
+
+;;;###autoload
+(defun remoto-copy-permalink ()
+  "Copy a permalink: the web URL pinned to the current commit SHA.
+Resolves the ref to a commit via the forge API so the link keeps
+pointing at the same content even after the branch advances."
+  (interactive)
+  (let* ((ctx (remoto--buffer-file-context))
+         (sha (remoto--resolve-commit-sha (plist-get ctx :owner)
+                                          (plist-get ctx :repo)
+                                          (plist-get ctx :ref))))
+    (remoto--kill-url (remoto--context-url ctx (plist-get ctx :kind) sha))))
+
+;;;###autoload
+(defun remoto-copy-raw-url ()
+  "Copy the raw-content URL for the current file."
+  (interactive)
+  (let ((ctx (remoto--buffer-file-context)))
+    (remoto--require-blob ctx "Raw URL")
+    (remoto--kill-url (remoto--context-url ctx 'raw))))
+
+;;;###autoload
+(defun remoto-copy-history-url ()
+  "Copy the commit-history URL for the current file or directory."
+  (interactive)
+  (let ((ctx (remoto--buffer-file-context)))
+    (remoto--kill-url (remoto--context-url ctx 'history))))
+
+;;;###autoload
+(defun remoto-browse-url ()
+  "Open the forge web page for the current file or directory in a browser."
+  (interactive)
+  (let* ((ctx (remoto--buffer-file-context))
+         (url (remoto--context-url ctx (plist-get ctx :kind))))
+    (browse-url url)
+    (message "Browsing: %s" url)))
+
+;;;###autoload
+(define-obsolete-function-alias 'remoto-copy-github-url 'remoto-copy-url "1.8.0")
 
 ;;;; Repository search
 
@@ -2618,6 +2776,63 @@ Matches the canonical /github: prefix and its /gh: shorthand alias.")
 (add-to-list 'completion-category-overrides
              '(remoto (styles partial-completion basic)))
 
+;;;; Minor mode
+
+(defvar remoto-command-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "u" #'remoto-copy-url)
+    (define-key map "b" #'remoto-copy-blame-url)
+    (define-key map "p" #'remoto-copy-permalink)
+    (define-key map "r" #'remoto-copy-raw-url)
+    (define-key map "h" #'remoto-copy-history-url)
+    (define-key map "w" #'remoto-browse-url)
+    map)
+  "Keymap of remoto URL commands, meant to be bound to a prefix key.
+
+Short mnemonic keys: `u' copy-url, `b' blame, `p' permalink, `r' raw,
+`h' history, `w' browse.  It is intentionally bound to no key by
+default, so it claims none of the user-reserved \\=`C-c LETTER\\=' space.
+Bind it as a unit under a prefix of your choice, e.g.:
+
+  (with-eval-after-load \\='remoto
+    (keymap-set remoto-mode-map \"C-c g\" remoto-command-map))")
+(fset 'remoto-command-map remoto-command-map)
+
+(defvar remoto-mode-map (make-sparse-keymap)
+  "Keymap for `remoto-mode'.
+Empty by default.  Populate it in your configuration, commonly by
+binding the variable `remoto-command-map' to a prefix key.")
+
+;;;###autoload
+(define-minor-mode remoto-mode
+  "Minor mode for buffers backed by a remoto virtual filesystem.
+
+Offers forge-agnostic commands to copy or open the web URL of the file
+or directory shown in the current buffer.  The commands work the same in
+file buffers and in Dired, and adapt to the forge behind the path (only
+GitHub today, but designed for more).
+
+`remoto-mode' is enabled automatically when visiting a remoto path.  Its
+keymap is empty by default; the commands are grouped in the variable
+`remoto-command-map', which you can bind to a prefix of your choosing."
+  :lighter " Remoto"
+  :keymap remoto-mode-map)
+
+(defun remoto--maybe-enable-mode ()
+  "Enable `remoto-mode' when the current buffer is a remoto buffer.
+Intended for `find-file-hook' and `dired-mode-hook'."
+  (let ((file (or buffer-file-name
+                  (and (derived-mode-p 'dired-mode)
+                       (if (listp dired-directory)
+                           (car dired-directory)
+                         dired-directory)))))
+    (when (and (stringp file)
+               (string-match-p remoto--handler-regexp file))
+      (remoto-mode 1))))
+
+(add-hook 'find-file-hook #'remoto--maybe-enable-mode)
+(add-hook 'dired-mode-hook #'remoto--maybe-enable-mode)
+
 (defun remoto--get-prop (candidate prop)
   "Get text property PROP from CANDIDATE.
 Searches from the end backwards, skipping trailing delimiters.
@@ -2797,6 +3012,8 @@ Adds the package directory to `load-path' if needed."
   (advice-remove 'dired #'remoto--dired-around-a)
   (advice-remove 'find-file-noselect #'remoto--find-file-around-a)
   (advice-remove 'read-file-name-internal #'remoto--read-file-name-internal-a)
+  (remove-hook 'find-file-hook #'remoto--maybe-enable-mode)
+  (remove-hook 'dired-mode-hook #'remoto--maybe-enable-mode)
   (clrhash remoto--tree-cache)
   (clrhash remoto--default-branch-cache)
   (clrhash remoto--branches-cache)

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -506,20 +506,65 @@
   (it "handles root"
     (expect (remoto--normalize-path "/") :to-equal "/")))
 
-;;; remoto-copy-github-url
+;;; Forge URL building
 
-(describe "remoto-copy-github-url"
+(describe "remoto--forge-type"
+  (it "maps the github prefix"
+    (expect (remoto--forge-type "/github:o/r@main:/x.el") :to-be 'github))
+
+  (it "maps the gh shorthand prefix"
+    (expect (remoto--forge-type "/gh:o/r:/x.el") :to-be 'github))
+
+  (it "returns nil for non-remoto input"
+    (expect (remoto--forge-type "/home/me/x.el") :to-be nil)
+    (expect (remoto--forge-type nil) :to-be nil)))
+
+(describe "remoto--forge-url"
+  (it "builds a blob URL with a single line"
+    (expect (remoto--forge-url 'github 'blob "o" "r" "main" "src/main.el" 3 nil)
+            :to-equal "https://github.com/o/r/blob/main/src/main.el#L3"))
+
+  (it "builds a blob URL with a line range"
+    (expect (remoto--forge-url 'github 'blob "o" "r" "main" "src/main.el" 2 4)
+            :to-equal "https://github.com/o/r/blob/main/src/main.el#L2-L4"))
+
+  (it "builds a blob URL with no line fragment"
+    (expect (remoto--forge-url 'github 'blob "o" "r" "main" "src/main.el" nil nil)
+            :to-equal "https://github.com/o/r/blob/main/src/main.el"))
+
+  (it "builds a tree URL"
+    (expect (remoto--forge-url 'github 'tree "o" "r" "main" "src" nil nil)
+            :to-equal "https://github.com/o/r/tree/main/src"))
+
+  (it "builds a blame URL with a line"
+    (expect (remoto--forge-url 'github 'blame "o" "r" "main" "src/main.el" 3 nil)
+            :to-equal "https://github.com/o/r/blame/main/src/main.el#L3"))
+
+  (it "builds a raw URL"
+    (expect (remoto--forge-url 'github 'raw "o" "r" "main" "src/main.el" nil nil)
+            :to-equal "https://raw.githubusercontent.com/o/r/main/src/main.el"))
+
+  (it "builds a history URL"
+    (expect (remoto--forge-url 'github 'history "o" "r" "main" "src/main.el" nil nil)
+            :to-equal "https://github.com/o/r/commits/main/src/main.el"))
+
+  (it "signals for an unknown forge"
+    (expect (remoto--forge-url 'bogus 'blob "o" "r" "main" "x" nil nil)
+            :to-throw 'user-error)))
+
+;;; remoto-copy-url
+
+(describe "remoto-copy-url"
   (it "copies file URL with line number from a file buffer"
     (remoto-test-with-cache
-      (let ((buffer-file-name "/github:testowner/testrepo@main:/src/main.el"))
-        (with-temp-buffer
-          (insert "line1\nline2\nline3\n")
-          (setq-local buffer-file-name "/github:testowner/testrepo@main:/src/main.el")
-          (goto-char (point-min))
-          (forward-line 2)
-          (remoto-copy-github-url)
-          (expect (car kill-ring)
-                  :to-equal "https://github.com/testowner/testrepo/blob/main/src/main.el#L3")))))
+      (with-temp-buffer
+        (insert "line1\nline2\nline3\n")
+        (setq-local buffer-file-name "/github:testowner/testrepo@main:/src/main.el")
+        (goto-char (point-min))
+        (forward-line 2)
+        (remoto-copy-url)
+        (expect (car kill-ring)
+                :to-equal "https://github.com/testowner/testrepo/blob/main/src/main.el#L3"))))
 
   (it "copies file URL with line range when region is active"
     (remoto-test-with-cache
@@ -531,7 +576,7 @@
         (set-mark (point))
         (forward-line 2)
         (activate-mark)
-        (remoto-copy-github-url)
+        (remoto-copy-url)
         (deactivate-mark)
         (expect (car kill-ring)
                 :to-equal "https://github.com/testowner/testrepo/blob/main/src/main.el#L2-L4"))))
@@ -543,7 +588,7 @@
         (setq-local dired-directory "/github:testowner/testrepo@main:/")
         (spy-on 'dired-get-filename :and-return-value
                 "/github:testowner/testrepo@main:/src")
-        (remoto-copy-github-url)
+        (remoto-copy-url)
         (expect (car kill-ring)
                 :to-equal "https://github.com/testowner/testrepo/tree/main/src"))))
 
@@ -554,7 +599,7 @@
         (setq-local dired-directory "/github:testowner/testrepo@main:/")
         (spy-on 'dired-get-filename :and-return-value
                 "/github:testowner/testrepo@main:/README.md")
-        (remoto-copy-github-url)
+        (remoto-copy-url)
         (expect (car kill-ring)
                 :to-equal "https://github.com/testowner/testrepo/blob/main/README.md"))))
 
@@ -564,13 +609,159 @@
         (dired-mode)
         (setq-local dired-directory "/github:testowner/testrepo@main:/")
         (spy-on 'dired-get-filename :and-return-value nil)
-        (remoto-copy-github-url)
+        (remoto-copy-url)
         (expect (car kill-ring)
                 :to-equal "https://github.com/testowner/testrepo/tree/main/"))))
 
   (it "signals error outside remoto buffers"
     (with-temp-buffer
-      (expect (remoto-copy-github-url) :to-throw 'user-error))))
+      (expect (remoto-copy-url) :to-throw 'user-error))))
+
+(describe "remoto-copy-github-url (obsolete alias)"
+  (it "still copies the file URL via the new command"
+    (remoto-test-with-cache
+      (with-temp-buffer
+        (insert "line1\nline2\nline3\n")
+        (setq-local buffer-file-name "/github:testowner/testrepo@main:/src/main.el")
+        (goto-char (point-min))
+        (forward-line 2)
+        (remoto-copy-github-url)
+        (expect (car kill-ring)
+                :to-equal "https://github.com/testowner/testrepo/blob/main/src/main.el#L3")))))
+
+;;; remoto-copy-blame-url
+
+(describe "remoto-copy-blame-url"
+  (it "copies the blame URL with the current line"
+    (remoto-test-with-cache
+      (with-temp-buffer
+        (insert "line1\nline2\nline3\n")
+        (setq-local buffer-file-name "/github:testowner/testrepo@main:/src/main.el")
+        (goto-char (point-min))
+        (forward-line 2)
+        (remoto-copy-blame-url)
+        (expect (car kill-ring)
+                :to-equal "https://github.com/testowner/testrepo/blame/main/src/main.el#L3"))))
+
+  (it "signals when invoked on a directory"
+    (remoto-test-with-cache
+      (with-temp-buffer
+        (dired-mode)
+        (setq-local dired-directory "/github:testowner/testrepo@main:/")
+        (spy-on 'dired-get-filename :and-return-value
+                "/github:testowner/testrepo@main:/src")
+        (expect (remoto-copy-blame-url) :to-throw 'user-error)))))
+
+;;; remoto-copy-permalink
+
+(describe "remoto-copy-permalink"
+  (it "copies a URL pinned to the resolved commit SHA"
+    (remoto-test-with-cache
+      (spy-on 'remoto--api :and-return-value '((sha . "abc123def456")))
+      (with-temp-buffer
+        (insert "line1\nline2\nline3\n")
+        (setq-local buffer-file-name "/github:testowner/testrepo@main:/src/main.el")
+        (goto-char (point-min))
+        (forward-line 2)
+        (remoto-copy-permalink)
+        (expect (car kill-ring)
+                :to-equal
+                "https://github.com/testowner/testrepo/blob/abc123def456/src/main.el#L3")))))
+
+;;; remoto-copy-raw-url
+
+(describe "remoto-copy-raw-url"
+  (it "copies the raw content URL for a file"
+    (remoto-test-with-cache
+      (with-temp-buffer
+        (setq-local buffer-file-name "/github:testowner/testrepo@main:/src/main.el")
+        (remoto-copy-raw-url)
+        (expect (car kill-ring)
+                :to-equal
+                "https://raw.githubusercontent.com/testowner/testrepo/main/src/main.el"))))
+
+  (it "signals when invoked on a directory"
+    (remoto-test-with-cache
+      (with-temp-buffer
+        (dired-mode)
+        (setq-local dired-directory "/github:testowner/testrepo@main:/")
+        (spy-on 'dired-get-filename :and-return-value
+                "/github:testowner/testrepo@main:/src")
+        (expect (remoto-copy-raw-url) :to-throw 'user-error)))))
+
+;;; remoto-copy-history-url
+
+(describe "remoto-copy-history-url"
+  (it "copies the file history URL"
+    (remoto-test-with-cache
+      (with-temp-buffer
+        (setq-local buffer-file-name "/github:testowner/testrepo@main:/src/main.el")
+        (remoto-copy-history-url)
+        (expect (car kill-ring)
+                :to-equal "https://github.com/testowner/testrepo/commits/main/src/main.el"))))
+
+  (it "copies the directory history URL from dired"
+    (remoto-test-with-cache
+      (with-temp-buffer
+        (dired-mode)
+        (setq-local dired-directory "/github:testowner/testrepo@main:/")
+        (spy-on 'dired-get-filename :and-return-value
+                "/github:testowner/testrepo@main:/src")
+        (remoto-copy-history-url)
+        (expect (car kill-ring)
+                :to-equal "https://github.com/testowner/testrepo/commits/main/src")))))
+
+;;; remoto-browse-url
+
+(describe "remoto-browse-url"
+  (it "opens the file web page in a browser"
+    (remoto-test-with-cache
+      (spy-on 'browse-url)
+      (with-temp-buffer
+        (insert "line1\nline2\nline3\n")
+        (setq-local buffer-file-name "/github:testowner/testrepo@main:/src/main.el")
+        (goto-char (point-min))
+        (forward-line 2)
+        (remoto-browse-url)
+        (expect 'browse-url :to-have-been-called-with
+                "https://github.com/testowner/testrepo/blob/main/src/main.el#L3")))))
+
+;;; remoto-mode
+
+(describe "remoto-mode"
+  (it "toggles on and off"
+    (with-temp-buffer
+      (remoto-mode 1)
+      (expect remoto-mode :to-be-truthy)
+      (remoto-mode -1)
+      (expect remoto-mode :to-be nil)))
+
+  (it "auto-enables for a remoto file path"
+    (with-temp-buffer
+      (setq-local buffer-file-name "/github:o/r@main:/x.el")
+      (remoto--maybe-enable-mode)
+      (expect remoto-mode :to-be-truthy)
+      (remoto-mode -1)))
+
+  (it "does not enable for a normal file path"
+    (with-temp-buffer
+      (setq-local buffer-file-name "/home/me/x.el")
+      (remoto--maybe-enable-mode)
+      (expect remoto-mode :to-be nil)))
+
+  (it "leaves remoto-mode-map empty (no reserved C-c LETTER bindings)"
+    (expect (keymapp remoto-mode-map) :to-be-truthy)
+    (expect remoto-mode-map :to-equal (make-sparse-keymap))
+    (expect (lookup-key remoto-mode-map (kbd "C-c")) :to-be nil))
+
+  (it "groups the url commands in remoto-command-map"
+    (expect (keymapp remoto-command-map) :to-be-truthy)
+    (expect (lookup-key remoto-command-map "u") :to-be 'remoto-copy-url)
+    (expect (lookup-key remoto-command-map "b") :to-be 'remoto-copy-blame-url)
+    (expect (lookup-key remoto-command-map "p") :to-be 'remoto-copy-permalink)
+    (expect (lookup-key remoto-command-map "r") :to-be 'remoto-copy-raw-url)
+    (expect (lookup-key remoto-command-map "h") :to-be 'remoto-copy-history-url)
+    (expect (lookup-key remoto-command-map "w") :to-be 'remoto-browse-url)))
 
 ;;; Repository search
 


### PR DESCRIPTION
Generalize remoto-copy-github-url into a forge-agnostic URL layer driven by a template registry (remoto-forge-url-templates), so supporting GitLab or other forges later is a data change rather than new command code.

New commands, all working in file buffers and Dired:
- remoto-copy-url (replaces remoto-copy-github-url, kept as obsolete alias)
- remoto-copy-blame-url
- remoto-copy-permalink (pins to the resolved commit SHA)
- remoto-copy-raw-url
- remoto-copy-history-url
- remoto-browse-url

Add remoto-mode, a minor mode that auto-activates in remoto buffers. Its keymap is empty by default to avoid the user-reserved C-c LETTER space; commands live in remoto-command-map, a prefix keymap users bind wherever they like.