### PR TITLE
Fix clone destination and open Magit after cloning

### DIFF
--- a/README.org
+++ b/README.org
@@ -121,7 +121,7 @@ Each target type has its own keymap of actions that reuse remoto's forge-agnosti
 | ~remoto-dir~    | ~/github:torvalds/linux@master:/fs~     | ~remoto-embark-dir-map~    |
 | ~remoto-file~   | ~/github:torvalds/linux@master:/README~ | ~remoto-embark-file-map~   |
 
-Run ~embark-act~ on a target to see its actions and keys. Cloning honors ~remoto-clone-url-type~, and Embark's built-in ~url~ target gains ~R~ to open a forge URL at point as a remoto path.
+Run ~embark-act~ on a target to see its actions and keys. Cloning honors ~remoto-clone-url-type~ and opens the clone's Magit status buffer when it finishes (~dired~ without Magit), and Embark's built-in ~url~ target gains ~R~ to open a forge URL at point as a remoto path.
 
 ** How does it work
 

--- a/changelog.org
+++ b/changelog.org
@@ -3,6 +3,15 @@
 
 Changes to the project, following Keep a Changelog conventions.
 
+* [1.9.0] - 2026-09-04
+
+** Fixed
+- Cloning from ~embark-act~ now clones into the directory you choose. ~read-directory-name~ hands back a tilde-abbreviated path (~~/code/repo/~) and ~start-process~ runs git without a shell, so git read ~~~ as an ordinary directory name and created ~./~/code/repo~ under its own working directory. The destination is expanded before git sees it.
+- The clone runs in a real local directory, and the "Clone into:" prompt starts there. A remoto buffer's ~default-directory~ names a repository on the forge, so it can be neither the working directory of a local process nor the base of a relative destination.
+
+** Added
+- A finished clone opens the Magit status buffer for it, or ~dired~ when Magit is not installed. Magit stays optional and is loaded only after a successful clone.
+
 * [1.8.1] - 2026-06-30
 
 ** Fixed

--- a/remoto-embark.el
+++ b/remoto-embark.el
@@ -35,6 +35,7 @@
 (declare-function remoto--forge-issue-url "remoto" (forge owner repo number))
 (declare-function remoto--forge-owner-url "remoto" (forge owner &optional kind))
 (declare-function dired-get-filename "dired" (&optional localp no-error-if-not-filep))
+(declare-function magit-status-setup-buffer "magit-status" (&optional directory))
 (defvar dired-directory)
 
 ;; Embark variables this file registers into.  Declared so it byte-compiles
@@ -346,14 +347,30 @@ For an issue the forge redirects to the issue page."
   (browse-url (apply #'remoto--forge-owner-url
                      (append (remoto--embark-owner-parts target) '(owner-repos)))))
 
+(defun remoto--clone-directory ()
+  "Return a local directory to run a clone in and resolve it against."
+  (if (file-remote-p default-directory)
+      (expand-file-name "~/")
+    default-directory))
+
+(defun remoto--clone-finished (dest event)
+  "Report EVENT for the clone into DEST, and visit DEST once it succeeded."
+  (message "remoto clone %s: %s" dest (string-trim event))
+  (when (string-prefix-p "finished" event)
+    (if (require 'magit nil t)
+        (magit-status-setup-buffer dest)
+      (dired dest))))
+
 (defun remoto--clone (url dest)
   "Clone URL into DEST asynchronously, showing progress in a buffer."
-  (let ((buffer (get-buffer-create "*remoto-clone*")))
+  (let* ((default-directory (remoto--clone-directory))
+         (dest (expand-file-name dest))
+         (buffer (get-buffer-create "*remoto-clone*")))
     (with-current-buffer buffer
       (let ((inhibit-read-only t)) (erase-buffer)))
     (set-process-sentinel
      (start-process "remoto-clone" buffer "git" "clone" url dest)
-     (lambda (_proc event) (message "remoto clone %s: %s" dest (string-trim event))))
+     (lambda (_proc event) (remoto--clone-finished dest event)))
     (display-buffer buffer)))
 
 (defun remoto-embark-clone (target)
@@ -362,8 +379,8 @@ The clone URL kind is governed by `remoto-clone-url-type'."
   (interactive "sRemoto repo: ")
   (let* ((ctx (remoto--embark-context target))
          (url (remoto--context-url ctx remoto-clone-url-type))
-         (dest (read-directory-name "Clone into: " nil nil nil
-                                    (plist-get ctx :repo))))
+         (dest (read-directory-name "Clone into: " (remoto--clone-directory)
+                                    nil nil (plist-get ctx :repo))))
     (remoto--clone url dest)))
 
 ;;;; Keymaps

--- a/remoto.el
+++ b/remoto.el
@@ -5,7 +5,7 @@
 ;; Author: Ag Ibragimov <agzam.ibragimov@gmail.com>
 ;; Maintainer: Ag Ibragimov <agzam.ibragimov@gmail.com>
 ;; Created: April 24, 2026
-;; Version: 1.8.1
+;; Version: 1.9.0
 ;; Keywords: tools vc
 ;; Homepage: https://github.com/agzam/remoto.el
 ;; Package-Requires: ((emacs "29.1") (ghub "4.0.0"))

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -3915,16 +3915,67 @@ Returns the full path after completion, or INPUT if no completion."
               "git@github.com:o/r.git" "/tmp/r/")))
 
   (it "is bound in the repo keymap"
-    (expect (lookup-key remoto-embark-repo-map "c") :to-be 'remoto-embark-clone)))
+    (expect (lookup-key remoto-embark-repo-map "c") :to-be 'remoto-embark-clone))
+
+  (it "prompts from a local directory when acting in a remoto buffer"
+    (spy-on 'remoto--clone)
+    (spy-on 'read-directory-name :and-return-value "/tmp/r/")
+    (let ((default-directory "/github:o/r:/"))
+      (remoto-embark-clone "/github:o/r:/"))
+    (expect (nth 1 (spy-calls-args-for 'read-directory-name 0))
+            :to-equal (expand-file-name "~/"))))
 
 (describe "remoto--clone"
-  (it "launches git clone with the url and dest"
+  (before-each
     (spy-on 'start-process :and-return-value nil)
     (spy-on 'set-process-sentinel)
-    (spy-on 'display-buffer)
+    (spy-on 'display-buffer))
+
+  (it "launches git clone with the url and dest"
     (remoto--clone "https://github.com/o/r.git" "/tmp/r/")
     (expect (nthcdr 2 (spy-calls-args-for 'start-process 0))
-            :to-equal '("git" "clone" "https://github.com/o/r.git" "/tmp/r/"))))
+            :to-equal '("git" "clone" "https://github.com/o/r.git" "/tmp/r/")))
+
+  (it "expands a tilde dest, which git would take literally"
+    (remoto--clone "https://github.com/o/r.git" "~/GitHub/agzam/r/")
+    (expect (nth 5 (spy-calls-args-for 'start-process 0))
+            :to-equal (expand-file-name "~/GitHub/agzam/r/")))
+
+  (it "resolves a relative dest against a local dir, not the remoto one"
+    (let ((default-directory "/github:o/r:/"))
+      (remoto--clone "https://github.com/o/r.git" "r/"))
+    (expect (nth 5 (spy-calls-args-for 'start-process 0))
+            :to-equal (expand-file-name "r/" (expand-file-name "~/"))))
+
+  (it "reports the clone through its sentinel"
+    (remoto--clone "https://github.com/o/r.git" "/tmp/r/")
+    (expect (functionp (nth 1 (spy-calls-args-for 'set-process-sentinel 0)))
+            :to-be-truthy)))
+
+(describe "remoto--clone-finished"
+  (let (visited)
+    (before-each (setq visited nil))
+
+    (it "opens magit-status on the clone when it succeeded"
+      (cl-letf (((symbol-function 'require) (lambda (f &rest _) (eq f 'magit)))
+                ((symbol-function 'magit-status-setup-buffer)
+                 (lambda (dir) (setq visited (cons 'magit dir)))))
+        (remoto--clone-finished "/tmp/r/" "finished\n"))
+      (expect visited :to-equal '(magit . "/tmp/r/")))
+
+    (it "falls back to dired when magit is unavailable"
+      (cl-letf (((symbol-function 'require) (lambda (&rest _) nil))
+                ((symbol-function 'dired) (lambda (dir) (setq visited (cons 'dired dir)))))
+        (remoto--clone-finished "/tmp/r/" "finished\n"))
+      (expect visited :to-equal '(dired . "/tmp/r/")))
+
+    (it "visits nothing when the clone failed"
+      (cl-letf (((symbol-function 'require) (lambda (f &rest _) (eq f 'magit)))
+                ((symbol-function 'magit-status-setup-buffer)
+                 (lambda (dir) (setq visited (cons 'magit dir))))
+                ((symbol-function 'dired) (lambda (dir) (setq visited (cons 'dired dir)))))
+        (remoto--clone-finished "/tmp/r/" "exited abnormally with code 128\n"))
+      (expect visited :to-be nil))))
 
 (describe "owner-level repo completion targets (Stage C)"
   (it "reports the remoto-repo category at owner level"


### PR DESCRIPTION
## Summary
- `remoto-embark-clone` cloned into a literal `~` directory under the current one. `read-directory-name` returns a tilde-abbreviated path and `start-process` runs git without a shell, so the destination is now expanded before git sees it.
- The git process runs in a real local directory, and the "Clone into:" prompt starts there. A remoto `default-directory` names a repository on the forge, so it is neither a working directory nor a base for a relative destination.
- A finished clone opens its Magit status buffer, `dired` when Magit is absent. Magit stays optional and is loaded only after a successful clone.

## Testing
- `make test` 527/0, `make test-embark` 62/0, `make check-compile` clean.
- 7 new specs. The 3 destination specs were confirmed to fail against the pre-fix code.
- End to end in a live Emacs: cloned from a `/github:` buffer into a tilde path, landed in the expanded directory with no `~` directory created, and the Magit status buffer for the clone came up.
