### PR TITLE
Fix completion after the colon and filter under orderless

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ $(ELPA_DIR):
 	--eval "(package-refresh-contents)" \
 	--eval "(package-install 'ghub)" \
 	--eval "(package-install 'buttercup)" \
-	--eval "(package-install 'embark)"
+	--eval "(package-install 'embark)" \
+	--eval "(package-install 'orderless)"
 
 deps: $(ELPA_DIR)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -308,7 +308,7 @@ Each level provides annotations via completion metadata `affixation-function`. A
 | files-default, canonical | Last commit message per file (up to 20 API calls, cached) |
 | issues | PR/Issue prefix + title + state; group-function: "Pull Request" vs "Issue" |
 
-PRs are sorted before issues. Completion category is set to `remoto` (with `partial-completion` style) to prevent Marginalia from overriding.
+PRs are sorted before issues. Completion category is set to a `remoto-*` category so Marginalia does not override the annotations. remoto sets no completion style for those categories: the file-name handler honors `completion-regexp-list` (as the built-in primitive and TRAMP do) and reads the typed query from the minibuffer when a style such as orderless passes an empty FILE, so the user's own `completion-styles` apply.
 
 #### Path normalization on RET
 

--- a/changelog.org
+++ b/changelog.org
@@ -3,6 +3,19 @@
 
 Changes to the project, following Keep a Changelog conventions.
 
+* [1.9.1] - 2026-09-09
+
+** Fixed
+- Selecting a candidate right after the colon of a canonical path (~/github:o/r@main:~, what picking a branch leaves in the minibuffer, or a hand-typed ~/github:o/r:~) no longer appends it to the typed text: typing ~t~ and choosing ~test/~ gave ~/github:o/r@main:ttest/~. ~file-name-directory~ synthesized a ~/~ after the colon, so its result was one character longer than the real prefix, and ~completion-file-name-table~ derives the completion boundary from that length; the boundary landed past the typed text and every completion UI inserted the candidate after it. The directory now comes back exactly as typed, the way TRAMP returns ~/ssh:host:~ for ~/ssh:host:t~.
+- Completion under ~orderless~ (or any style that filters through ~completion-regexp-list~) now filters. Such styles hand the table only the text up to the completion boundary and express the typed text as regexps the table is expected to apply, as the built-in ~file-name-all-completions~ and TRAMP do. The handler ignored them and returned every candidate, so the wanted entry sat at the bottom of an unfiltered list. Files, branches, tags, repos, issues (matched on number and title), and accounts now honor ~completion-regexp-list~, with case folding per ~completion-ignore-case~.
+- The search levels (accounts at ~/github:~, repos at ~/github:OWNER/~, issues at ~/github:OWNER/REPO#~) and ~remoto-browse~ received an empty query under those styles, so they showed "recent" or "top" lists and never searched for what was typed. When the table is asked with an empty FILE, the query now comes from the active minibuffer, so a repo outside the recent list, an issue found by title, and a ~remoto-browse~ search all work under orderless as they do under ~basic~.
+
+** Changed
+- remoto no longer writes ~completion-category-overrides~. That variable belongs to the user, and a ~setq~ in a user config that runs after remoto loads (common with orderless setups) wiped the entries anyway, which is how the unfiltered lists above appeared. With the table style-agnostic, the user's own ~completion-styles~ apply inside remoto as everywhere else: substring and multi-component matching under orderless, prefix matching under ~basic~. The ~remoto-*~ completion categories stay in the metadata for annotations, grouping, and Embark.
+
+** Added
+- ~orderless~ as a test dependency, with end-to-end specs that run ~completion-all-completions~ under the orderless style for every level and for ~remoto-browse~, boundary specs for the canonical no-slash forms, and regexp-filter specs per level.
+
 * [1.9.0] - 2026-09-04
 
 ** Fixed

--- a/remoto.el
+++ b/remoto.el
@@ -5,7 +5,7 @@
 ;; Author: Ag Ibragimov <agzam.ibragimov@gmail.com>
 ;; Maintainer: Ag Ibragimov <agzam.ibragimov@gmail.com>
 ;; Created: April 24, 2026
-;; Version: 1.9.0
+;; Version: 1.9.1
 ;; Keywords: tools vc
 ;; Homepage: https://github.com/agzam/remoto.el
 ;; Package-Requires: ((emacs "29.1") (ghub "4.0.0"))
@@ -747,46 +747,120 @@ Preserves OWNER's text properties (used for affixation) and attaches a
   (propertize (concat owner "/")
               'remoto-target (concat "/github:" (substring-no-properties owner))))
 
+(defun remoto--minibuffer-input ()
+  "Contents of the current buffer when it is an active completion minibuffer."
+  (when (and (minibufferp) minibuffer-completion-table)
+    (minibuffer-contents-no-properties)))
+
+(defun remoto--input-query (input directory)
+  "Text that INPUT holds after DIRECTORY, or nil when INPUT is elsewhere.
+INPUT goes through `substitute-in-file-name' first, the normalization
+`read-file-name' applies, so a shadowed prefix such as \"~/x//github:o/\"
+and the /gh: shorthand both resolve to DIRECTORY.  Nil as well when the
+text after DIRECTORY holds a level delimiter: `partial-completion'
+probes parent levels with an empty FILE while the input sits deeper,
+and that probe must not turn the deeper path into a search query."
+  (when-let* ((effective (condition-case nil
+                             (substitute-in-file-name input)
+                           (error input)))
+              ((string-prefix-p directory effective))
+              (rest (substring effective (length directory)))
+              ((not (string-match-p (rx (any "/@#:")) rest))))
+    rest))
+
+(defun remoto--minibuffer-query (directory)
+  "What the user typed after DIRECTORY in the active minibuffer, or nil.
+Completion styles that express the typed text as `completion-regexp-list'
+\(orderless) hand the table only the text up to the completion boundary,
+so FILE in `file-name-all-completions' arrives empty; the search levels
+need the typed text as their API query."
+  (when-let* ((input (remoto--minibuffer-input)))
+    (remoto--input-query input directory)))
+
+(defun remoto--completion-query (file directory)
+  "Search query for FILE in DIRECTORY: FILE, or the minibuffer text if empty."
+  (if (string-empty-p file)
+      (or (remoto--minibuffer-query directory) file)
+    file))
+
+(defun remoto--candidate-match-text (candidate)
+  "Text that `completion-regexp-list' is matched against for CANDIDATE.
+The bare number of an issue and the bare name of a repo or account are
+rarely what the user types, so the title or description joins the
+name.  The trailing / or : delimiter stays out, as the built-in file
+name primitives match names without it."
+  (let ((name (string-trim-right candidate "[/:]"))
+        (extra (or (remoto--get-prop candidate 'remoto-topic-title)
+                   (remoto--get-prop candidate 'remoto-repo-desc)
+                   (remoto--get-prop candidate 'remoto-acct-desc))))
+    (if (and (stringp extra) (not (string-empty-p extra)))
+        (concat name " " extra)
+      name)))
+
+(defun remoto--filter-by-completion-regexps (candidates)
+  "Drop the CANDIDATES that `completion-regexp-list' rejects.
+Completion styles rely on the table applying `completion-regexp-list'
+itself: the built-in `file-name-all-completions' and TRAMP both do, and
+orderless never filters on its own.  Case folding follows
+`completion-ignore-case', as in the built-in primitives."
+  (if (null completion-regexp-list)
+      candidates
+    (let ((case-fold-search completion-ignore-case))
+      (seq-filter (lambda (c)
+                    (let ((text (remoto--candidate-match-text c)))
+                      (seq-every-p (lambda (re) (string-match-p re text))
+                                   completion-regexp-list)))
+                  candidates))))
+
 (defun remoto--handle-file-name-all-completions (file directory)
   "Return completions for FILE in remote DIRECTORY.
+Applies `completion-regexp-list' like the built-in primitive does."
+  (remoto--filter-by-completion-regexps
+   (remoto--file-name-completions file directory)))
+
+(defun remoto--file-name-completions (file directory)
+  "Return unfiltered completions for FILE in remote DIRECTORY.
 Handles multiple levels: user search at /github:, repo listing at
 /github:OWNER/, branch/tag at /github:OWNER/REPO@, files at
 /github:OWNER/REPO/, issues at /github:OWNER/REPO#, and file
 listing within a repo.  Search-level calls (user, repo) are
 non-blocking: cached results are returned immediately while async
-fetches populate the cache in the background."
+fetches populate the cache in the background.
+An empty FILE does not mean an empty query: see `remoto--minibuffer-query'."
   (if-let* ((partial (remoto--parse-partial-github-path directory)))
       (pcase (plist-get partial :level)
         ('root
          ;; Empty query + authenticated: show user + orgs
-         ;; Non-empty: search users/orgs matching FILE (non-blocking)
-         (if (string-empty-p file)
-             (when-let* ((user remoto--authenticated-user))
-               (let* ((orgs (remoto--fetch-user-orgs user))
-                      (all (cons (propertize user 'remoto-acct-type "User") orgs)))
-                 (mapcar #'remoto--owner-candidate all)))
-           (when-let* ((result (remoto--search-users file)))
-             (let ((filtered (seq-filter (lambda (u) (string-prefix-p file u))
-                                         result)))
-               ;; Pre-fetch repos for the top match so the cache is
-               ;; warm by the time the user types "/"
-               (when-let* ((top (car filtered)))
-                 (remoto--prefetch-owner-repos top))
-               (mapcar #'remoto--owner-candidate filtered)))))
+         ;; Non-empty: search users/orgs matching the query (non-blocking)
+         (let ((query (remoto--completion-query file directory)))
+           (if (string-empty-p query)
+               (when-let* ((user remoto--authenticated-user))
+                 (let* ((orgs (remoto--fetch-user-orgs user))
+                        (all (cons (propertize user 'remoto-acct-type "User") orgs)))
+                   (mapcar #'remoto--owner-candidate all)))
+             (when-let* ((result (remoto--search-users query)))
+               (let ((filtered (seq-filter (lambda (u) (string-prefix-p file u))
+                                           result)))
+                 ;; Pre-fetch repos for the top match so the cache is
+                 ;; warm by the time the user types "/"
+                 (when-let* ((top (car filtered)))
+                   (remoto--prefetch-owner-repos top))
+                 (mapcar #'remoto--owner-candidate filtered))))))
         ('owner
          ;; Repo completion at /github:OWNER/
          ;; Try cached/async results first; on cold-cache nil, fall
          ;; back to a synchronous fetch that yields to user input.
          (let* ((owner (plist-get partial :owner))
-                (repos (if (string-empty-p file)
+                (query (remoto--completion-query file directory))
+                (repos (if (string-empty-p query)
                            (remoto--recent-owner-repos owner)
-                         (remoto--search-owner-repos owner file))))
+                         (remoto--search-owner-repos owner query))))
            (unless repos
              (let ((sync (while-no-input
-                           (if (string-empty-p file)
+                           (if (string-empty-p query)
                                (remoto--recent-owner-repos-sync owner)
-                             (when (<= remoto-min-search-chars (length file))
-                               (remoto--search-owner-repos-sync owner file))))))
+                             (when (<= remoto-min-search-chars (length query))
+                               (remoto--search-owner-repos-sync owner query))))))
                (when (consp sync)
                  (setq repos sync))))
            (mapcar (lambda (r)
@@ -878,18 +952,19 @@ fetches populate the cache in the background."
          ;; Issue/PR completion at /github:OWNER/REPO#
          (let* ((owner (plist-get partial :owner))
                 (repo (plist-get partial :repo))
+                (query (remoto--completion-query file directory))
                 (issues
                  (cond
                   ;; Empty query: show top open issues
-                  ((string-empty-p file)
+                  ((string-empty-p query)
                    (while-no-input
                      (remoto--fetch-issues owner repo)))
                   ;; Numeric query: direct fetch + filter cached
-                  ((string-match-p (rx bos (+ digit) eos) file)
+                  ((string-match-p (rx bos (+ digit) eos) query)
                    (let* ((cached (while-no-input
                                     (remoto--fetch-issues owner repo)))
                           (direct (while-no-input
-                                    (remoto--fetch-issue owner repo file)))
+                                    (remoto--fetch-issue owner repo query)))
                           (results (if (listp cached) cached nil)))
                      (if direct
                          (cl-remove-duplicates
@@ -899,7 +974,7 @@ fetches populate the cache in the background."
                   ;; Text query: search
                   (t
                    (while-no-input
-                     (remoto--search-issues owner repo file))))))
+                     (remoto--search-issues owner repo query))))))
            (when (listp issues)
              (let* ((candidates
                      (mapcar (lambda (i)
@@ -1078,15 +1153,20 @@ Handles partial paths including # and files-default short forms."
     (if (string-match (rx bos "/github:" eos) filename)
         "/github:"
       "/github:"))
-   ;; Full canonical path
+   ;; Full canonical path.  The result must be a prefix of FILENAME:
+   ;; `completion-file-name-table' derives the completion boundary from
+   ;; its length, so a synthesized "/" after the colon would push the
+   ;; boundary past the text being completed and make the UI append the
+   ;; candidate to it.  Hence the raw path, not the parsed one, which
+   ;; normalizes "" to "/".
    (t
-    (when-let* ((parsed (remoto--parse-path filename))
-                (prefix (remoto--file-name-prefix filename)))
-      (let* ((path (remoto-path-path parsed))
+    (when-let* ((prefix (remoto--file-name-prefix filename))
+                (_ (remoto--parse-path filename)))
+      (let* ((path (substring filename (length prefix)))
              (dir (if (string-suffix-p "/" path)
                       path
                     (file-name-directory path))))
-        (concat prefix (or dir "/")))))))
+        (concat prefix (or dir "")))))))
 
 (defun remoto--handle-file-name-nondirectory (filename)
   "Return non-directory part of remote FILENAME.
@@ -2614,10 +2694,18 @@ Handles search, branch, and issue modes."
   "Programmed completion table for GitHub repos, branches, and issues.
 STRING is the current minibuffer input, PRED a filter predicate,
 ACTION the completion action dispatched by `completing-read'.
-Detects @ and # delimiters to switch between modes."
-  (if (eq action 'metadata)
-      (remoto--browse-metadata string)
-    (complete-with-action action (remoto--browse-completions string) string pred)))
+Detects @ and # delimiters to switch between modes.
+Styles that filter by `completion-regexp-list' pass an empty STRING (the
+table has no boundaries); the minibuffer then supplies the query, and
+`complete-with-action' applies the regexps to the resulting list."
+  (cond
+   ((eq action 'metadata) (remoto--browse-metadata string))
+   ((eq (car-safe action) 'boundaries) nil)
+   (t (let ((input (if (string-empty-p string)
+                       (or (remoto--minibuffer-input) string)
+                     string)))
+        (complete-with-action action (remoto--browse-completions input)
+                              string pred)))))
 
 (defun remoto--read-repo ()
   "Read a GitHub repo from the minibuffer with search completion.
@@ -2880,23 +2968,6 @@ Matches the canonical /github: prefix and its /gh: shorthand alias.")
 ;; Clear the fetch indicator and reset in-flight state whenever a
 ;; minibuffer exits.  `add-hook' is idempotent, so reloading is safe.
 (add-hook 'minibuffer-exit-hook #'remoto--minibuffer-exit-cleanup)
-
-;; Register completion styles for our category so filtering works
-;; like file-name completion (partial-completion understands path
-;; separators).  Uses overrides (highest priority) so that a global
-;; orderless in completion-styles does not interfere.
-(add-to-list 'completion-category-overrides
-             '(remoto (styles partial-completion basic)))
-(add-to-list 'completion-category-overrides
-             '(remoto-repo (styles partial-completion basic)))
-(add-to-list 'completion-category-overrides
-             '(remoto-file (styles partial-completion basic)))
-(add-to-list 'completion-category-overrides
-             '(remoto-branch (styles partial-completion basic)))
-(add-to-list 'completion-category-overrides
-             '(remoto-issue (styles partial-completion basic)))
-(add-to-list 'completion-category-overrides
-             '(remoto-owner (styles partial-completion basic)))
 
 ;;;; Minor mode
 

--- a/test/remoto-tests.el
+++ b/test/remoto-tests.el
@@ -1867,12 +1867,12 @@
       (remoto--handle-file-name-all-completions "li" "/github:torvalds/")
       (expect 'remoto--search-owner-repos-sync :not :to-have-been-called))))
 
-(describe "completion-category-overrides registration"
-  (it "registers remoto category with partial-completion style"
-    (let ((entry (assq 'remoto completion-category-overrides)))
-      (expect entry :to-be-truthy)
-      (expect (cdr (assq 'styles (cdr entry)))
-              :to-equal '(partial-completion basic)))))
+(describe "completion style registration"
+  (it "leaves the user's completion-category-overrides alone"
+    (dolist (cat '(remoto remoto-repo remoto-file remoto-branch
+                   remoto-issue remoto-owner remoto-browse))
+      (expect (assq cat completion-category-overrides) :to-be nil)
+      (expect (assq cat completion-category-defaults) :to-be nil))))
 
 (describe "remoto--get-authenticated-user"
   (it "returns login from /user endpoint"
@@ -1971,16 +1971,17 @@
                     "s" "/github:testowner/testrepo@main:/")))
         (expect (member "src/" files) :to-be-truthy))))
 
-  (it "orderless-style: searches then filters client-side"
-    ;; This simulates what orderless does with the new search-based approach
+  (it "orderless-style: empty FILE, query from the minibuffer, regexps applied"
+    ;; orderless hands the table only the boundary prefix and expresses
+    ;; the typed text as `completion-regexp-list'.
     (spy-on 'remoto--search-owner-repos :and-return-value
             '("linux" "libdc-for-dirk"))
-    ;; orderless calls with a query, gets matching repos
-    (let ((all (remoto--handle-file-name-all-completions "li" "/github:torvalds/")))
-      (expect (length all) :to-equal 2)
-      ;; Then filters client-side (prefix still matches through trailing /)
-      (let ((filtered (seq-filter (lambda (r) (string-prefix-p "lin" r)) all)))
-        (expect filtered :to-equal '("linux/"))))))
+    (spy-on 'remoto--minibuffer-input :and-return-value "/github:torvalds/lin")
+    (let ((completion-regexp-list '("lin")))
+      (expect (remoto--handle-file-name-all-completions "" "/github:torvalds/")
+              :to-equal '("linux/"))
+      (expect 'remoto--search-owner-repos
+              :to-have-been-called-with "torvalds" "lin"))))
 
 ;;; Pre-repo completions
 
@@ -3983,10 +3984,6 @@ Returns the full path after completion, or INPUT if no completion."
            (cat (alist-get 'category meta)))
       (expect cat :to-be 'remoto-repo)))
 
-  (it "registers a completion-category-override for remoto-repo"
-    (let ((override (assq 'remoto-repo completion-category-overrides)))
-      (expect override :to-be-truthy)))
-
   (it "attaches the full remoto path as a remoto-target property on candidates"
     (spy-on 'remoto--recent-owner-repos :and-return-value
             (list (propertize "remoto.el" 'remoto-repo-desc "desc")))
@@ -4006,10 +4003,6 @@ Returns the full path after completion, or INPUT if no completion."
     (let* ((meta (remoto--completion-metadata "/github:o/r/"))
            (cat (alist-get 'category meta)))
       (expect cat :to-be 'remoto-file)))
-
-  (it "registers a completion-category-override for remoto-file"
-    (let ((override (assq 'remoto-file completion-category-overrides)))
-      (expect override :to-be-truthy)))
 
   (it "attaches remoto-target on files-default candidates"
     (spy-on 'remoto--default-branch :and-return-value "main")
@@ -4050,10 +4043,6 @@ Returns the full path after completion, or INPUT if no completion."
     (let* ((meta (remoto--completion-metadata "/github:o/r@"))
            (cat (alist-get 'category meta)))
       (expect cat :to-be 'remoto-branch)))
-
-  (it "registers a completion-category-override for remoto-branch"
-    (let ((override (assq 'remoto-branch completion-category-overrides)))
-      (expect override :to-be-truthy)))
 
   (it "attaches remoto-target on branch candidates"
     (spy-on 'remoto--fetch-branches :and-return-value '("main" "dev"))
@@ -4096,10 +4085,6 @@ Returns the full path after completion, or INPUT if no completion."
     (let* ((meta (remoto--completion-metadata "/github:o/r#"))
            (cat (alist-get 'category meta)))
       (expect cat :to-be 'remoto-issue)))
-
-  (it "registers a completion-category-override for remoto-issue"
-    (let ((override (assq 'remoto-issue completion-category-overrides)))
-      (expect override :to-be-truthy)))
 
   (it "attaches remoto-target on issue candidates"
     (spy-on 'remoto--fetch-issues :and-return-value
@@ -4253,6 +4238,350 @@ Returns the full path after completion, or INPUT if no completion."
                                  remoto-owner remoto-browse))
         (let ((rt (funcall survives cat)))
           (expect rt :to-equal "/github:x/y:/"))))))
+
+;;; Completion boundaries and style-agnostic filtering
+
+(defun remoto-test--all-completions (input &optional styles table)
+  "Candidates and base for INPUT under STYLES, as a completion UI computes them.
+TABLE defaults to `read-file-name-internal'.  The base is the last cdr
+of `completion-all-completions'; Vertico inserts a candidate as
+\(concat (substring INPUT 0 base) candidate)."
+  (let* ((completion-styles (or styles '(basic)))
+         (completion-category-overrides nil)
+         (completion-category-defaults nil)
+         (all (completion-all-completions input (or table #'read-file-name-internal)
+                                          nil (length input)))
+         (base (or (when-let* ((z (last all))) (prog1 (cdr z) (setcdr z nil))) 0)))
+    (cons (mapcar #'substring-no-properties all) base)))
+
+(describe "completion boundary after the colon"
+  (it "file-name-directory of a canonical path is a prefix of it"
+    (dolist (input '("/github:o/r@main:s" "/github:o/r:s" "/github:o/r@main:"
+                     "/github:o/r@main:/" "/github:o/r@main:/s"
+                     "/github:o/r@main:src/m"))
+      (expect (string-prefix-p (remoto--handle-file-name-directory input) input)
+              :to-be-truthy)))
+
+  (it "returns the typed prefix when the path has no directory part"
+    (expect (remoto--handle-file-name-directory "/github:o/r@main:s")
+            :to-equal "/github:o/r@main:")
+    (expect (remoto--handle-file-name-directory "/github:o/r:s")
+            :to-equal "/github:o/r:")
+    (expect (remoto--handle-file-name-directory "/github:o/r@main:")
+            :to-equal "/github:o/r@main:"))
+
+  (it "keeps the slash when it was typed"
+    (expect (remoto--handle-file-name-directory "/github:o/r@main:/")
+            :to-equal "/github:o/r@main:/")
+    (expect (remoto--handle-file-name-directory "/github:o/r@main:/src/m")
+            :to-equal "/github:o/r@main:/src/")
+    (expect (remoto--handle-file-name-directory "/github:o/r@main:src/m")
+            :to-equal "/github:o/r@main:src/"))
+
+  (it "puts the completion field after the colon, not at the end of the input"
+    (expect (completion-boundaries "/github:o/r@main:s" #'read-file-name-internal nil "")
+            :to-equal '(17 . 0))
+    (expect (completion-boundaries "/github:o/r:s" #'read-file-name-internal nil "")
+            :to-equal '(12 . 0)))
+
+  (it "replaces the typed text with the selected candidate after a branch pick"
+    (remoto-test-with-cache
+      (spy-on 'remoto--fetch-file-commits :and-return-value nil)
+      (pcase-let ((`(,cands . ,base)
+                   (remoto-test--all-completions "/github:testowner/testrepo@main:s")))
+        (expect cands :to-equal '("src/"))
+        (expect (concat (substring "/github:testowner/testrepo@main:s" 0 base) "src/")
+                :to-equal "/github:testowner/testrepo@main:src/"))
+      (pcase-let ((`(,_ . ,base)
+                   (remoto-test--all-completions "/github:testowner/testrepo:s")))
+        (expect (concat (substring "/github:testowner/testrepo:s" 0 base) "src/")
+                :to-equal "/github:testowner/testrepo:src/"))))
+
+  (it "resolves the slash-less canonical path that results"
+    (remoto-test-with-cache
+      (expect (remoto--handle-file-exists-p "/github:testowner/testrepo@main:src/main.el")
+              :to-be-truthy)
+      (expect (remoto--handle-file-directory-p "/github:testowner/testrepo@main:src/")
+              :to-be-truthy)
+      (spy-on 'remoto--fetch-file-commits :and-return-value nil)
+      (expect (remoto--handle-file-name-all-completions "" "/github:testowner/testrepo@main:src/")
+              :to-equal '("main.el" "utils.el")))))
+
+(describe "completion-regexp-list in file-name-all-completions"
+  (it "applies every regexp, like the built-in primitive"
+    (remoto-test-with-cache
+      (spy-on 'remoto--fetch-file-commits :and-return-value nil)
+      (let ((completion-regexp-list '("s")))
+        (expect (remoto--handle-file-name-all-completions "" "/github:testowner/testrepo@main:/")
+                :to-equal '("src/")))
+      (let ((completion-regexp-list '("R" "md")))
+        (expect (remoto--handle-file-name-all-completions "" "/github:testowner/testrepo@main:/")
+                :to-equal '("README.md")))
+      (let ((completion-regexp-list '("nothing")))
+        (expect (remoto--handle-file-name-all-completions "" "/github:testowner/testrepo@main:/")
+                :to-be nil))))
+
+  (it "returns everything when no regexps are set"
+    (remoto-test-with-cache
+      (spy-on 'remoto--fetch-file-commits :and-return-value nil)
+      (let ((completion-regexp-list nil))
+        (expect (remoto--handle-file-name-all-completions "" "/github:testowner/testrepo@main:/")
+                :to-equal '("README.md" "bin/" "src/")))))
+
+  (it "matches the name without the trailing slash"
+    (remoto-test-with-cache
+      (spy-on 'remoto--fetch-file-commits :and-return-value nil)
+      (let ((completion-regexp-list '("src$")))
+        (expect (remoto--handle-file-name-all-completions "" "/github:testowner/testrepo@main:/")
+                :to-equal '("src/")))))
+
+  (it "follows completion-ignore-case"
+    (remoto-test-with-cache
+      (spy-on 'remoto--fetch-file-commits :and-return-value nil)
+      (let ((completion-regexp-list '("readme")))
+        (let ((completion-ignore-case nil))
+          (expect (remoto--handle-file-name-all-completions "" "/github:testowner/testrepo@main:/")
+                  :to-be nil))
+        (let ((completion-ignore-case t))
+          (expect (remoto--handle-file-name-all-completions "" "/github:testowner/testrepo@main:/")
+                  :to-equal '("README.md"))))))
+
+  (it "filters the files-default listing"
+    (spy-on 'remoto--default-branch :and-return-value "main")
+    (spy-on 'remoto--fetch-dir-children-light :and-return-value
+            '(("README.md" . ((type . "blob"))) ("src" . ((type . "tree")))))
+    (let ((completion-regexp-list '("sr")))
+      (expect (remoto--handle-file-name-all-completions "" "/github:o/r/")
+              :to-equal '("src/"))))
+
+  (it "filters branches and tags by name without the colon"
+    (spy-on 'remoto--fetch-branches :and-return-value '("main" "develop"))
+    (spy-on 'remoto--fetch-tags :and-return-value '("v1.0"))
+    (let ((completion-regexp-list '("v")))
+      (expect (remoto--handle-file-name-all-completions "" "/github:o/r@")
+              :to-equal '("develop:" "v1.0:")))
+    (let ((completion-regexp-list '("main$")))
+      (expect (remoto--handle-file-name-all-completions "" "/github:o/r@")
+              :to-equal '("main:"))))
+
+  (it "matches issues by number or title"
+    (spy-on 'remoto--fetch-issues :and-return-value
+            '(((number . 42) (title . "forty-two") (state . "open"))
+              ((number . 10) (title . "ten") (state . "open"))))
+    (let ((completion-regexp-list '("forty")))
+      (expect (remoto--handle-file-name-all-completions "" "/github:o/r#")
+              :to-equal '("42")))
+    (let ((completion-regexp-list '("1")))
+      (expect (remoto--handle-file-name-all-completions "" "/github:o/r#")
+              :to-equal '("10"))))
+
+  (it "matches repos by name or description"
+    (spy-on 'remoto--recent-owner-repos :and-return-value
+            (list (propertize "dotfiles" 'remoto-repo-desc "my emacs config")
+                  (propertize "remoto.el" 'remoto-repo-desc "browse github")))
+    (let ((completion-regexp-list '("emacs")))
+      (expect (remoto--handle-file-name-all-completions "" "/github:agzam/")
+              :to-equal '("dotfiles/")))
+    (let ((completion-regexp-list '("remoto")))
+      (expect (remoto--handle-file-name-all-completions "" "/github:agzam/")
+              :to-equal '("remoto.el/"))))
+
+  (it "matches accounts by login or description"
+    (let ((remoto--authenticated-user "me"))
+      (spy-on 'remoto--fetch-user-orgs :and-return-value
+              (list (propertize "acme" 'remoto-acct-type "Organization"
+                                'remoto-acct-desc "Rockets")))
+      (let ((completion-regexp-list '("rock"))
+            (completion-ignore-case t))
+        (expect (remoto--handle-file-name-all-completions "" "/github:")
+                :to-equal '("acme/")))
+      (let ((completion-regexp-list '("me")))
+        (expect (remoto--handle-file-name-all-completions "" "/github:")
+                :to-equal '("me/" "acme/"))))))
+
+(describe "typed query recovery for regexp-filtering styles"
+  (it "extracts the text after DIRECTORY from the input"
+    (expect (remoto--input-query "/github:torvalds/lin" "/github:torvalds/") :to-equal "lin")
+    (expect (remoto--input-query "/github:tor" "/github:") :to-equal "tor")
+    (expect (remoto--input-query "/github:o/r#bug" "/github:o/r#") :to-equal "bug"))
+
+  (it "normalizes the /gh: shorthand and a shadowed prefix"
+    (expect (remoto--input-query "/gh:torvalds/lin" "/github:torvalds/") :to-equal "lin")
+    (expect (remoto--input-query "~/x//github:torvalds/lin" "/github:torvalds/")
+            :to-equal "lin"))
+
+  (it "returns nil when the input is not under DIRECTORY"
+    (expect (remoto--input-query "/github:other/lin" "/github:torvalds/") :to-be nil)
+    (expect (remoto--input-query "/tmp/x" "/github:torvalds/") :to-be nil))
+
+  (it "returns nil when the input sits at a deeper level than DIRECTORY"
+    (expect (remoto--input-query "/github:kn66/repo@" "/github:") :to-be nil)
+    (expect (remoto--input-query "/github:kn66/repo@" "/github:kn66/") :to-be nil)
+    (expect (remoto--input-query "/github:o/r#12" "/github:o/") :to-be nil)
+    (expect (remoto--input-query "/github:o/r@main:/src" "/github:o/r@") :to-be nil))
+
+  (it "does not turn a parent-level probe into a search"
+    ;; partial-completion probes /github: and /github:kn66/ with FILE ""
+    ;; while the minibuffer holds /github:kn66/repo@.
+    (spy-on 'remoto--minibuffer-input :and-return-value "/github:kn66/repo@")
+    (spy-on 'remoto--search-users)
+    (spy-on 'remoto--search-owner-repos)
+    (spy-on 'remoto--recent-owner-repos :and-return-value '("repo"))
+    (let ((remoto--authenticated-user nil))
+      (expect (remoto--handle-file-name-all-completions "" "/github:") :to-be nil))
+    (expect (remoto--handle-file-name-all-completions "" "/github:kn66/")
+            :to-equal '("repo/"))
+    (expect 'remoto--search-users :not :to-have-been-called)
+    (expect 'remoto--search-owner-repos :not :to-have-been-called))
+
+  (it "prefers a non-empty FILE over the minibuffer"
+    (spy-on 'remoto--minibuffer-input :and-return-value "/github:torvalds/other")
+    (expect (remoto--completion-query "lin" "/github:torvalds/") :to-equal "lin"))
+
+  (it "falls back to the minibuffer text when FILE is empty"
+    (spy-on 'remoto--minibuffer-input :and-return-value "/github:torvalds/lin")
+    (expect (remoto--completion-query "" "/github:torvalds/") :to-equal "lin"))
+
+  (it "yields an empty query outside a completion minibuffer"
+    (expect (remoto--minibuffer-input) :to-be nil)
+    (expect (remoto--completion-query "" "/github:torvalds/") :to-equal ""))
+
+  (it "reads the real minibuffer when it is current"
+    (with-current-buffer (window-buffer (minibuffer-window))
+      (unwind-protect
+          (let ((minibuffer-completion-table #'read-file-name-internal))
+            (insert "/github:torvalds/lin")
+            (expect (remoto--minibuffer-input) :to-equal "/github:torvalds/lin")
+            (expect (remoto--minibuffer-query "/github:torvalds/") :to-equal "lin"))
+        (erase-buffer))))
+
+  (it "ignores a minibuffer that is not completing"
+    (with-current-buffer (window-buffer (minibuffer-window))
+      (unwind-protect
+          (let ((minibuffer-completion-table nil))
+            (insert "/github:torvalds/lin")
+            (expect (remoto--minibuffer-input) :to-be nil))
+        (erase-buffer))))
+
+  (it "searches users with the minibuffer text at the root"
+    (spy-on 'remoto--minibuffer-input :and-return-value "/github:tor")
+    (spy-on 'remoto--search-users :and-return-value '("torvalds"))
+    (expect (remoto--handle-file-name-all-completions "" "/github:")
+            :to-equal '("torvalds/"))
+    (expect 'remoto--search-users :to-have-been-called-with "tor"))
+
+  (it "searches issues with the minibuffer text"
+    (spy-on 'remoto--minibuffer-input :and-return-value "/github:o/r#bug")
+    (spy-on 'remoto--search-issues :and-return-value
+            '(((number . 7) (title . "a bug") (state . "open"))))
+    (expect (remoto--handle-file-name-all-completions "" "/github:o/r#")
+            :to-equal '("7"))
+    (expect 'remoto--search-issues :to-have-been-called-with "o" "r" "bug"))
+
+  (it "fetches an issue by number from the minibuffer text"
+    (spy-on 'remoto--minibuffer-input :and-return-value "/github:o/r#42")
+    (spy-on 'remoto--fetch-issues :and-return-value nil)
+    (spy-on 'remoto--fetch-issue :and-return-value
+            '((number . 42) (title . "x") (state . "open")))
+    (expect (remoto--handle-file-name-all-completions "" "/github:o/r#")
+            :to-equal '("42"))
+    (expect 'remoto--fetch-issue :to-have-been-called-with "o" "r" "42")))
+
+(describe "remoto--repo-completion-table under regexp-filtering styles"
+  (it "takes the query from the minibuffer when STRING is empty"
+    (spy-on 'remoto--minibuffer-input :and-return-value "agzam/rem")
+    (spy-on 'remoto--search-repos :and-return-value '("agzam/remoto.el"))
+    (let ((completion-regexp-list '("rem")))
+      (expect (remoto--repo-completion-table "" nil t) :to-equal '("agzam/remoto.el")))
+    (expect 'remoto--search-repos :to-have-been-called-with "agzam/rem"))
+
+  (it "still applies the regexps to the candidates"
+    (spy-on 'remoto--minibuffer-input :and-return-value "agzam/rem")
+    (spy-on 'remoto--search-repos :and-return-value '("agzam/remoto.el" "agzam/other"))
+    (let ((completion-regexp-list '("remoto")))
+      (expect (remoto--repo-completion-table "" nil t) :to-equal '("agzam/remoto.el"))))
+
+  (it "does not search for the boundaries action"
+    (spy-on 'remoto--search-repos)
+    (expect (remoto--repo-completion-table "agzam/rem" nil '(boundaries . "")) :to-be nil)
+    (expect 'remoto--search-repos :not :to-have-been-called))
+
+  (it "uses STRING when it is non-empty"
+    (spy-on 'remoto--minibuffer-input :and-return-value "ignored")
+    (spy-on 'remoto--search-repos :and-return-value '("agzam/remoto.el"))
+    (expect (remoto--repo-completion-table "agzam/rem" nil t) :to-equal '("agzam/remoto.el"))
+    (expect 'remoto--search-repos :to-have-been-called-with "agzam/rem")))
+
+(require 'orderless)
+
+(describe "end-to-end under the orderless completion style"
+  (it "filters the file listing to the typed text"
+    (remoto-test-with-cache
+      (spy-on 'remoto--fetch-file-commits :and-return-value nil)
+      (let ((input "/github:testowner/testrepo@main:/s"))
+        (spy-on 'remoto--minibuffer-input :and-return-value input)
+        (expect (remoto-test--all-completions input '(orderless))
+                :to-equal '(("src/") . 33)))))
+
+  (it "matches anywhere in the name, as orderless does elsewhere"
+    (remoto-test-with-cache
+      (spy-on 'remoto--fetch-file-commits :and-return-value nil)
+      (let ((input "/github:testowner/testrepo@main:/md"))
+        (spy-on 'remoto--minibuffer-input :and-return-value input)
+        (expect (car (remoto-test--all-completions input '(orderless)))
+                :to-equal '("README.md")))))
+
+  (it "runs the owner repo search with the typed text"
+    (let ((input "/github:torvalds/lin"))
+      (spy-on 'remoto--minibuffer-input :and-return-value input)
+      (spy-on 'remoto--search-owner-repos :and-return-value '("linux" "libdc-for-dirk"))
+      (expect (remoto-test--all-completions input '(orderless))
+              :to-equal '(("linux/") . 17))
+      (expect 'remoto--search-owner-repos :to-have-been-called-with "torvalds" "lin")))
+
+  (it "runs the user search with the typed text at the root"
+    (let ((input "/github:tor"))
+      (spy-on 'remoto--minibuffer-input :and-return-value input)
+      (spy-on 'remoto--search-users :and-return-value '("torvalds"))
+      (expect (remoto-test--all-completions input '(orderless))
+              :to-equal '(("torvalds/") . 8))
+      (expect 'remoto--search-users :to-have-been-called-with "tor")))
+
+  (it "finds issues by title"
+    (let ((input "/github:o/r#forty"))
+      (spy-on 'remoto--minibuffer-input :and-return-value input)
+      (spy-on 'remoto--search-issues :and-return-value
+              '(((number . 42) (title . "forty-two") (state . "open"))))
+      (expect (remoto-test--all-completions input '(orderless))
+              :to-equal '(("42") . 12))
+      (expect 'remoto--search-issues :to-have-been-called-with "o" "r" "forty")))
+
+  (it "filters branches and tags"
+    (let ((input "/github:o/r@dev"))
+      (spy-on 'remoto--minibuffer-input :and-return-value input)
+      (spy-on 'remoto--fetch-branches :and-return-value '("main" "develop"))
+      (spy-on 'remoto--fetch-tags :and-return-value '("v1.0"))
+      (expect (remoto-test--all-completions input '(orderless))
+              :to-equal '(("develop:") . 12))))
+
+  (it "inserts the candidate in place of the typed text after a branch pick"
+    (remoto-test-with-cache
+      (spy-on 'remoto--fetch-file-commits :and-return-value nil)
+      (let ((input "/github:testowner/testrepo@main:s"))
+        (spy-on 'remoto--minibuffer-input :and-return-value input)
+        (pcase-let ((`(,cands . ,base) (remoto-test--all-completions input '(orderless))))
+          (expect cands :to-equal '("src/"))
+          (expect (concat (substring input 0 base) "src/")
+                  :to-equal "/github:testowner/testrepo@main:src/")))))
+
+  (it "runs the repo search in remoto-browse with the typed text"
+    (let ((input "agzam/rem"))
+      (spy-on 'remoto--minibuffer-input :and-return-value input)
+      (spy-on 'remoto--search-repos :and-return-value '("agzam/remoto.el" "agzam/other"))
+      (expect (car (remoto-test--all-completions
+                    input '(orderless) #'remoto--repo-completion-table))
+              :to-equal '("agzam/remoto.el"))
+      (expect 'remoto--search-repos :to-have-been-called-with "agzam/rem"))))
 
 (provide 'remoto-tests)
 


### PR DESCRIPTION
## Summary
- Selecting a candidate right after the colon of a canonical path (`/github:o/r@main:`, what picking a branch leaves in the minibuffer, or a hand-typed `/github:o/r:`) appended it to the typed text: `t` + `test/` gave `...:ttest/`. `file-name-directory` synthesized a `/` after the colon, so its result was one character longer than the real prefix, and `completion-file-name-table` derives the completion boundary from that length. The directory now comes back as typed, the way TRAMP returns `/ssh:host:` for `/ssh:host:t`. Closes agzam/remoto.el#31.
- Completion under orderless (or any style filtering through `completion-regexp-list`) now filters. Such styles hand the table only the boundary prefix and expect it to apply the regexps, as the built-in `file-name-all-completions` and TRAMP do; the handler ignored them and returned everything, so the match sat at the bottom of an unfiltered list. Files, branches, tags, repos (name + description), issues (number + title), and accounts honor `completion-regexp-list`, with case folding per `completion-ignore-case`.
- The search levels (`/github:`, `/github:OWNER/`, `/github:OWNER/REPO#`) and `remoto-browse` received an empty query under those styles and showed "recent"/"top" lists instead of searching. With an empty FILE inside a completion minibuffer, the query now comes from the minibuffer text after the directory. `partial-completion` probes parent levels with an empty FILE while the input sits deeper, so a remainder holding a level delimiter is not taken as a query.
- remoto no longer writes `completion-category-overrides`. The variable belongs to the user, and a `setq` running after remoto loads wiped the entries anyway, which is how the unfiltered lists appeared. The `remoto-*` categories stay in the metadata for annotations, grouping, and Embark; the user's own `completion-styles` apply inside remoto as everywhere else.

## Testing
- `make test` 563/0, `make test-embark` 62/0, `make check-compile` clean; checkdoc and package-lint unchanged from `main`.
- `orderless` added to the test dependencies. New specs: completion boundaries for the no-slash canonical forms, `completion-regexp-list` filtering per level, minibuffer query recovery (including the parent-level probe guard and a real minibuffer buffer), `remoto--repo-completion-table`, and end-to-end `completion-all-completions` under the orderless style for every level and `remoto-browse`. They fail 34 times against the pre-fix `remoto.el`.
- End to end in a live Emacs with `completion-styles '(orderless partial-completion basic)` and the overrides wiped by the user config, driving a real `read-file-name` with Vertico: pick `main:`, type `v`, `vertico-insert` -> `/github:kn66/vertico-posframe-preview@main:vertico-posframe-preview/`; `org` -> `README.org`; `pre el` -> `vertico-posframe-preview.el`; owner level `vert` -> the four vertico repos with the search receiving `vert`; root `kn6` -> async user search. The only searches issued were `(owner-repos "kn66" "vert")` and `(users "kn6")`.
